### PR TITLE
feat: Auto generate JWT Token signing secret

### DIFF
--- a/device-management/.env.example
+++ b/device-management/.env.example
@@ -22,7 +22,3 @@ TAKSA_DM_DATABASE_SOURCE=postgres://user:password@localhost:5432/taksa_platform_
 TAKSA_DM_BASE_URL=http://localhost:8000
 TAKSA_DM_UMH_CORE_DOCKER_IMAGE=management.umh.app/oci/united-manufacturing-hub/umh-core:v0.43.17
 
-# JWT signing secret for device authentication tokens (REQUIRED)
-# Used to sign and verify JWT tokens issued during device login
-# MUST be changed from default in production deployments
-TAKSA_DM_JWT_SECRET=change-me-in-production

--- a/device-management/cmd/device-management/main.go
+++ b/device-management/cmd/device-management/main.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/artpark-hub/taksa-platform/device-management/internal/conf"
+	"github.com/artpark-hub/taksa-platform/device-management/internal/utils"
 
 	"github.com/go-kratos/kratos/v2"
 	"github.com/go-kratos/kratos/v2/config"
@@ -141,9 +144,17 @@ func main() {
 	if jwtSecret := os.Getenv("TAKSA_DM_JWT_SECRET"); jwtSecret != "" {
 		bc.Server.JwtSecret = jwtSecret
 	}
-	if bc.Server.JwtSecret == "" {
-		panic("TAKSA_DM_JWT_SECRET is required (set in .env, config.yaml server.jwt_secret, or environment)")
+
+	// Get or generate JWT secret (generate-once, persist-under-/data strategy)
+	// Treat quoted empty strings ("" or \"\" from YAML) as needing generation
+	if strings.TrimSpace(bc.Server.JwtSecret) == "" || bc.Server.JwtSecret == `""` {
+		bc.Server.JwtSecret = ""
 	}
+	jwtSecret, err := utils.GetOrGenerateJWTSecret(bc.Server.JwtSecret)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to get or generate JWT secret: %v", err))
+	}
+	bc.Server.JwtSecret = jwtSecret
 
 	// Initialize Zap logger based on config log_level and log_file
 	zapLogger, err := newZapLogger(bc.LogLevel, bc.LogFile)

--- a/device-management/cmd/device-management/main.go
+++ b/device-management/cmd/device-management/main.go
@@ -152,7 +152,7 @@ func main() {
 	}
 	jwtSecret, err := utils.GetOrGenerateJWTSecret(bc.Server.JwtSecret)
 	if err != nil {
-		panic(fmt.Sprintf("Failed to get or generate JWT secret: %v", err))
+		panic(fmt.Errorf("Failed to get or generate JWT secret: %w", err))
 	}
 	bc.Server.JwtSecret = jwtSecret
 

--- a/device-management/configs/config.yaml
+++ b/device-management/configs/config.yaml
@@ -5,7 +5,7 @@ server:
   grpc:
     addr: 0.0.0.0:9000
     timeout: 1s
-  jwt_secret: ""  # REQUIRED: override via TAKSA_DM_JWT_SECRET env var
+  jwt_secret:   # OPTIONAL: Leave empty to autogenerate. Can override via TAKSA_DM_JWT_SECRET env var
 log_level: debug  # Options: debug, info, warn, error, production
 log_file: /data/taksa-device-management.log  # Log file path (logs to both console and file)
 data:

--- a/device-management/configs/config.yaml
+++ b/device-management/configs/config.yaml
@@ -5,7 +5,7 @@ server:
   grpc:
     addr: 0.0.0.0:9000
     timeout: 1s
-  jwt_secret:   # OPTIONAL: Leave empty to autogenerate. Can override via TAKSA_DM_JWT_SECRET env var
+  jwt_secret: ""   # OPTIONAL: Leave empty to autogenerate. Can override via TAKSA_DM_JWT_SECRET env var
 log_level: debug  # Options: debug, info, warn, error, production
 log_file: /data/taksa-device-management.log  # Log file path (logs to both console and file)
 data:

--- a/device-management/docker-compose.yml
+++ b/device-management/docker-compose.yml
@@ -17,9 +17,9 @@ services:
       - TAKSA_DM_GRPC_PORT=${TAKSA_DM_GRPC_PORT:-9000}
       - TAKSA_DM_DATABASE_SOURCE=${TAKSA_DM_DATABASE_SOURCE:-postgres://user:password@localhost/taksa_platform_dm?sslmode=disable}
       - TAKSA_DM_DATABASE_DRIVER=${TAKSA_DM_DATABASE_DRIVER:-postgres}
-      - TAKSA_DM_BASE_URL=${TAKSA_DM_BASE_URL:-http://localhost:8000}
+      - TAKSA_DM_BASE_URL=${TAKSA_DM_BASE_URL:-http://$TAKSA_DOMAIN:$TAKSA_DM_HTTP_PORT}
       - TAKSA_DM_UMH_CORE_DOCKER_IMAGE=${TAKSA_DM_UMH_CORE_DOCKER_IMAGE:-management.umh.app/oci/united-manufacturing-hub/umh-core:v0.43.17}
-      - TAKSA_DM_JWT_SECRET=${TAKSA_DM_JWT_SECRET}
+      - TAKSA_DM_JWT_SECRET
     volumes:
       - ${TAKSA_DM_DATA_DIR:-./data}:/data
     networks:

--- a/device-management/docker-compose.yml
+++ b/device-management/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - TAKSA_DM_DATABASE_DRIVER=${TAKSA_DM_DATABASE_DRIVER:-postgres}
       - TAKSA_DM_BASE_URL=${TAKSA_DM_BASE_URL:-http://localhost:8000}
       - TAKSA_DM_UMH_CORE_DOCKER_IMAGE=${TAKSA_DM_UMH_CORE_DOCKER_IMAGE:-management.umh.app/oci/united-manufacturing-hub/umh-core:v0.43.17}
-      - TAKSA_DM_JWT_SECRET=${TAKSA_DM_JWT_SECRET:-change-me-in-production}
+      - TAKSA_DM_JWT_SECRET=${TAKSA_DM_JWT_SECRET}
     volumes:
       - ${TAKSA_DM_DATA_DIR:-./data}:/data
     networks:

--- a/device-management/docs/JWT_SECRET_GENERATION.md
+++ b/device-management/docs/JWT_SECRET_GENERATION.md
@@ -1,0 +1,210 @@
+# JWT Secret Generation and Persistence
+
+## Overview
+
+The device-management service now implements **generate-once, persist-under-/data** strategy for JWT signing secrets. This eliminates the need to manually configure `TAKSA_DM_JWT_SECRET` in environment variables or `config.yaml` for each deployment.
+
+## Behavior
+
+### Priority Order
+
+The JWT secret resolution follows this priority:
+
+1. **Explicit Configuration** (highest priority)
+   - Environment variable: `TAKSA_DM_JWT_SECRET`
+   - Config file: `server.jwt_secret` in `config.yaml`
+   - Use if non-empty
+
+2. **Persisted Secret**
+   - Check for existing secret at `/data/jwt.secret`
+   - Use if found (ensures session continuity across restarts)
+
+3. **Generate and Persist** (lowest priority)
+   - Generate new 256-bit (32-byte) random secret
+   - Convert to hex string (64 characters)
+   - Write to `/data/jwt.secret` with restrictive permissions (0600)
+   - Return for immediate use
+
+### Session Continuity
+
+By persisting the secret to `/data/` (a persistent volume mount), the service automatically maintains session continuity across restarts:
+
+- On first start: Generates and persists a secret → devices can login and receive cookies
+- On restart: Reads persisted secret → existing device cookies remain valid
+- No manual intervention required
+
+## Implementation Details
+
+### File Location
+
+- **Default path**: `/data/jwt.secret`
+- **Permissions**: `0600` (owner read/write only)
+- **Format**: Hex-encoded string (64 characters)
+
+### Code Changes
+
+#### `internal/utils/jwt_secret.go`
+
+Provides two main functions:
+
+```go
+// Standard usage (uses /data/jwt.secret)
+secret, err := utils.GetOrGenerateJWTSecret(envSecret)
+
+// Testing with custom path
+secret, err := utils.GetOrGenerateJWTSecretWithPath(envSecret, "/custom/path")
+```
+
+#### `cmd/device-management/main.go`
+
+Replaces the panic on missing secret with automatic generation:
+
+```go
+// Old (before)
+if bc.Server.JwtSecret == "" {
+    panic("TAKSA_DM_JWT_SECRET is required...")
+}
+
+// New (after)
+jwtSecret, err := utils.GetOrGenerateJWTSecret(bc.Server.JwtSecret)
+if err != nil {
+    panic(err)
+}
+bc.Server.JwtSecret = jwtSecret
+```
+
+## Usage
+
+### Docker Deployment
+
+No changes needed to existing deployments:
+
+```yaml
+services:
+  device-management:
+    image: device-management:latest
+    volumes:
+      - data:/data
+    # TAKSA_DM_JWT_SECRET can be omitted or left empty
+```
+
+The service will:
+1. Start up
+2. Check for `/data/jwt.secret`
+3. Generate one if missing
+4. Use it for all JWT operations
+
+### Local Development
+
+```bash
+# First run: generates /data/jwt.secret
+go run ./cmd/device-management/main.go
+
+# Subsequent runs: reuse existing /data/jwt.secret
+go run ./cmd/device-management/main.go
+```
+
+### Testing
+
+All tests use `GetOrGenerateJWTSecretWithPath()` with temporary directories:
+
+```bash
+go test ./internal/utils/...
+```
+
+## Security Considerations
+
+### Random Generation
+
+- Uses `crypto/rand.Read()` for cryptographically secure randomness
+- 256-bit (32-byte) secrets provide 2^256 possible values
+
+### File Permissions
+
+- `0600` (owner read/write only) — prevents unauthorized access
+- Directory created with `0755` (standard) — needed for path traversal
+- Mounted as `/data` in containers with appropriate ownership
+
+### No Automatic Rotation
+
+Secrets are **not** rotated automatically. If a new secret is needed:
+
+1. Delete `/data/jwt.secret`
+2. Restart the service
+3. New secret is generated
+
+This prevents session disruption while still allowing manual rotation when needed.
+
+## Troubleshooting
+
+### Secret Generation Fails
+
+If the service panics with "failed to generate JWT secret":
+
+1. Check that `/data` directory is writable
+2. Ensure sufficient disk space
+3. Check file system permissions
+
+**Example error:**
+```
+panic: failed to generate JWT secret: failed to create directory /data: permission denied
+```
+
+**Solution:**
+```bash
+# Verify mount point
+mount | grep /data
+# Should show: <volume> on /data type <fstype> (rw,...)
+
+# Fix permissions if needed
+chmod 755 /data
+```
+
+### Secret Persists Between Deployments
+
+This is **intentional behavior** — the secret survives restarts to maintain session continuity.
+
+If you need to reset:
+```bash
+# In the container or volume
+rm /data/jwt.secret
+
+# Restart service (will generate new secret)
+```
+
+### Cannot Access /data
+
+If `/data` is not available (e.g., testing without persistent volume):
+
+1. The service will try to create `/data` at runtime
+2. If the host filesystem is read-only, this fails
+3. For testing, set `TAKSA_DM_JWT_SECRET` explicitly:
+
+```bash
+export TAKSA_DM_JWT_SECRET="test-secret"
+go run ./cmd/device-management/main.go
+```
+
+## Integration with Auth
+
+The secret is passed to:
+
+- **AuthUsecase** (`internal/biz/auth.go`): Uses for JWT signing in `GenerateJWT()`, verification in `VerifyJWT()`
+- **HTTP Server** (`internal/server/http.go`): Uses for middleware JWT validation via `HTTPTenantMiddleware`
+
+Both consume `bc.Server.JwtSecret`, which is now automatically set.
+
+## Testing
+
+Unit tests cover:
+
+1. ✅ **Env secret priority** — Explicit config takes precedence
+2. ✅ **File generation** — Random secret created and written to disk
+3. ✅ **File reading** — Persisted secret read on subsequent calls
+4. ✅ **Persistence** — Same secret returned across multiple calls
+5. ✅ **File permissions** — Secret file created with 0600 mode
+
+Run tests:
+```bash
+go test -v ./internal/utils/...
+```

--- a/device-management/docs/JWT_SECRET_GENERATION.md
+++ b/device-management/docs/JWT_SECRET_GENERATION.md
@@ -66,9 +66,16 @@ if bc.Server.JwtSecret == "" {
 }
 
 // New (after)
-jwtSecret, err := utils.GetOrGenerateJWTSecret(bc.Server.JwtSecret)
+jwtSecret := strings.TrimSpace(bc.Server.JwtSecret)
+if jwtSecret == `""` {
+    jwtSecret = ""
+} else if len(jwtSecret) >= 2 && strings.HasPrefix(jwtSecret, `"`) && strings.HasSuffix(jwtSecret, `"`) {
+    jwtSecret = strings.Trim(jwtSecret, `"`)
+}
+
+jwtSecret, err := utils.GetOrGenerateJWTSecret(jwtSecret)
 if err != nil {
-    panic(err)
+    panic(fmt.Sprintf("failed to get or generate JWT secret: %v", err))
 }
 bc.Server.JwtSecret = jwtSecret
 ```

--- a/device-management/docs/JWT_SECRET_GENERATION.md
+++ b/device-management/docs/JWT_SECRET_GENERATION.md
@@ -67,15 +67,9 @@ if bc.Server.JwtSecret == "" {
 
 // New (after)
 jwtSecret := strings.TrimSpace(bc.Server.JwtSecret)
-if jwtSecret == `""` {
-    jwtSecret = ""
-} else if len(jwtSecret) >= 2 && strings.HasPrefix(jwtSecret, `"`) && strings.HasSuffix(jwtSecret, `"`) {
-    jwtSecret = strings.Trim(jwtSecret, `"`)
-}
-
 jwtSecret, err := utils.GetOrGenerateJWTSecret(jwtSecret)
 if err != nil {
-    panic(fmt.Sprintf("failed to get or generate JWT secret: %v", err))
+    panic(err)
 }
 bc.Server.JwtSecret = jwtSecret
 ```

--- a/device-management/internal/utils/jwt_secret.go
+++ b/device-management/internal/utils/jwt_secret.go
@@ -1,0 +1,95 @@
+package utils
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	// DefaultJWTSecretFile is the default path for persisting the JWT secret under /data
+	DefaultJWTSecretFile = "/data/jwt.secret"
+	// JWTSecretLength is the length of the random secret in bytes (32 bytes = 256 bits)
+	JWTSecretLength = 32
+)
+
+// GetOrGenerateJWTSecret returns a JWT signing secret.
+// Priority:
+// 1. If envSecret is not empty, use it (TAKSA_DM_JWT_SECRET from env/config)
+// 2. If /data/jwt.secret exists, read and return it
+// 3. Otherwise, generate a new random secret, persist it to /data/jwt.secret, and return it
+//
+// This ensures session continuity across service restarts while avoiding
+// the need to manually configure TAKSA_DM_JWT_SECRET for each deployment.
+func GetOrGenerateJWTSecret(envSecret string) (string, error) {
+	return GetOrGenerateJWTSecretWithPath(envSecret, DefaultJWTSecretFile)
+}
+
+// GetOrGenerateJWTSecretWithPath is like GetOrGenerateJWTSecret but allows
+// specifying a custom path for the persisted secret (useful for testing).
+func GetOrGenerateJWTSecretWithPath(envSecret, filePath string) (string, error) {
+	// 1. Explicit configuration takes highest priority
+	if envSecret != "" {
+		return envSecret, nil
+	}
+
+	// 2. Check for persisted secret
+	secret, err := readJWTSecretFromFile(filePath)
+	if err == nil {
+		return secret, nil
+	}
+	// If file doesn't exist, we'll generate a new one
+	if !os.IsNotExist(err) {
+		return "", fmt.Errorf("failed to read JWT secret file: %w", err)
+	}
+
+	// 3. Generate and persist a new secret
+	secret, err = generateAndPersistJWTSecret(filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate JWT secret: %w", err)
+	}
+
+	return secret, nil
+}
+
+// readJWTSecretFromFile reads the JWT secret from a file
+func readJWTSecretFromFile(filePath string) (string, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+
+	secret := string(data)
+	if secret == "" {
+		return "", fmt.Errorf("JWT secret file is empty")
+	}
+
+	return secret, nil
+}
+
+// generateAndPersistJWTSecret generates a random secret and writes it to a file
+func generateAndPersistJWTSecret(filePath string) (string, error) {
+	// Ensure the directory exists
+	dir := filepath.Dir(filePath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create directory %s: %w", dir, err)
+	}
+
+	// Generate random bytes
+	bytes := make([]byte, JWTSecretLength)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", fmt.Errorf("failed to generate random bytes: %w", err)
+	}
+
+	// Convert to hex string
+	secret := hex.EncodeToString(bytes)
+
+	// Write to file with restrictive permissions (owner read/write only)
+	if err := os.WriteFile(filePath, []byte(secret), 0600); err != nil {
+		return "", fmt.Errorf("failed to write JWT secret to %s: %w", filePath, err)
+	}
+
+	return secret, nil
+}

--- a/device-management/internal/utils/jwt_secret.go
+++ b/device-management/internal/utils/jwt_secret.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 const (
@@ -54,16 +55,17 @@ func GetOrGenerateJWTSecretWithPath(envSecret, filePath string) (string, error) 
 	return secret, nil
 }
 
-// readJWTSecretFromFile reads the JWT secret from a file
+// readJWTSecretFromFile reads the JWT secret from a file and trims whitespace/newlines
+// to prevent issues when secrets are created with echo or have trailing newlines
 func readJWTSecretFromFile(filePath string) (string, error) {
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return "", err
 	}
 
-	secret := string(data)
+	secret := strings.TrimSpace(string(data))
 	if secret == "" {
-		return "", fmt.Errorf("%w: JWT secret file is empty", os.ErrNotExist)
+		return "", fmt.Errorf("%w: JWT secret file is empty or contains only whitespace", os.ErrNotExist)
 	}
 
 	return secret, nil

--- a/device-management/internal/utils/jwt_secret.go
+++ b/device-management/internal/utils/jwt_secret.go
@@ -41,17 +41,22 @@ func GetOrGenerateJWTSecretWithPath(envSecret, filePath string) (string, error) 
 	if err == nil {
 		return secret, nil
 	}
-	// If file doesn't exist, we'll generate a new one
-	if !os.IsNotExist(err) {
-		return "", fmt.Errorf("failed to read JWT secret file: %w", err)
+	
+	// If file doesn't exist, generate a new one
+	if os.IsNotExist(err) {
+		secret, err = generateAndPersistJWTSecret(filePath)
+		if err != nil {
+			return "", fmt.Errorf("failed to generate JWT secret: %w", err)
+		}
+		return secret, nil
 	}
-
-	// 3. Generate and persist a new secret
+	
+	// 3. File exists but is invalid (empty/whitespace-only)
+	// Regenerate and overwrite the corrupted file
 	secret, err = generateAndPersistJWTSecret(filePath)
 	if err != nil {
-		return "", fmt.Errorf("failed to generate JWT secret: %w", err)
+		return "", fmt.Errorf("failed to regenerate JWT secret after detecting corrupted file: %w", err)
 	}
-
 	return secret, nil
 }
 
@@ -65,7 +70,8 @@ func readJWTSecretFromFile(filePath string) (string, error) {
 
 	secret := strings.TrimSpace(string(data))
 	if secret == "" {
-		return "", fmt.Errorf("%w: JWT secret file is empty or contains only whitespace", os.ErrNotExist)
+		// File exists but contains only whitespace - this is an error condition
+		return "", fmt.Errorf("JWT secret file is empty or contains only whitespace")
 	}
 
 	return secret, nil

--- a/device-management/internal/utils/jwt_secret.go
+++ b/device-management/internal/utils/jwt_secret.go
@@ -63,7 +63,7 @@ func readJWTSecretFromFile(filePath string) (string, error) {
 
 	secret := string(data)
 	if secret == "" {
-		return "", fmt.Errorf("JWT secret file is empty")
+		return "", fmt.Errorf("%w: JWT secret file is empty", os.ErrNotExist)
 	}
 
 	return secret, nil

--- a/device-management/internal/utils/jwt_secret_test.go
+++ b/device-management/internal/utils/jwt_secret_test.go
@@ -154,14 +154,31 @@ func TestGetOrGenerateJWTSecretRejectsWhitespaceOnly(t *testing.T) {
 	tmpDir := t.TempDir()
 	testFilePath := filepath.Join(tmpDir, "jwt.secret")
 
-	// Write only whitespace/newlines
+	// Write only whitespace/newlines (corrupted file)
 	if err := os.WriteFile(testFilePath, []byte("   \n  \t  \n"), 0600); err != nil {
 		t.Fatalf("failed to setup test file: %v", err)
 	}
 
-	// Should fail because file is whitespace-only
-	_, err := GetOrGenerateJWTSecretWithPath("", testFilePath)
-	if err == nil {
-		t.Errorf("expected error for whitespace-only file, got nil")
+	// Should regenerate the corrupted file (not error)
+	secret, err := GetOrGenerateJWTSecretWithPath("", testFilePath)
+	if err != nil {
+		t.Errorf("unexpected error for corrupted file: %v", err)
+	}
+
+	// Should have generated a valid secret
+	if secret == "" {
+		t.Errorf("expected valid secret, got empty string")
+	}
+	if len(secret) != 64 { // 32 bytes * 2 hex chars
+		t.Errorf("expected hex secret length 64, got %d", len(secret))
+	}
+
+	// File should be overwritten with new secret
+	fileContent, err := os.ReadFile(testFilePath)
+	if err != nil {
+		t.Fatalf("failed to read file after regeneration: %v", err)
+	}
+	if string(fileContent) != secret {
+		t.Errorf("file content doesn't match returned secret: got %q, expected %q", string(fileContent), secret)
 	}
 }

--- a/device-management/internal/utils/jwt_secret_test.go
+++ b/device-management/internal/utils/jwt_secret_test.go
@@ -1,0 +1,130 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetOrGenerateJWTSecret(t *testing.T) {
+	tests := []struct {
+		name           string
+		envSecret      string
+		setupFile      bool
+		expectedErr    bool
+		expectedSecret string
+		description    string
+	}{
+		{
+			name:           "env_secret_takes_priority",
+			envSecret:      "explicit-secret-from-env",
+			setupFile:      false,
+			expectedErr:    false,
+			expectedSecret: "explicit-secret-from-env",
+			description:    "Should use env secret if provided",
+		},
+		{
+			name:           "generate_and_persist",
+			envSecret:      "",
+			setupFile:      false,
+			expectedErr:    false,
+			expectedSecret: "", // We'll check it's non-empty and hex
+			description:    "Should generate and persist a new secret",
+		},
+		{
+			name:           "read_persisted_secret",
+			envSecret:      "",
+			setupFile:      true,
+			expectedErr:    false,
+			expectedSecret: "pre-existing-secret-value",
+			description:    "Should read persisted secret from file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary directory for test
+			tmpDir := t.TempDir()
+			testFilePath := filepath.Join(tmpDir, "jwt.secret")
+
+			// Setup file if needed
+			if tt.setupFile {
+				if err := os.WriteFile(testFilePath, []byte(tt.expectedSecret), 0600); err != nil {
+					t.Fatalf("failed to setup test file: %v", err)
+				}
+			}
+
+			// Call the function with custom path
+			secret, err := GetOrGenerateJWTSecretWithPath(tt.envSecret, testFilePath)
+
+			// Check error
+			if tt.expectedErr && err == nil {
+				t.Errorf("expected error but got none")
+			}
+			if !tt.expectedErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			// Check secret value
+			if tt.expectedSecret != "" {
+				if secret != tt.expectedSecret {
+					t.Errorf("expected %q, got %q", tt.expectedSecret, secret)
+				}
+			} else if tt.name == "generate_and_persist" {
+				// For generated secrets, check it's non-empty and looks like hex
+				if secret == "" {
+					t.Errorf("expected non-empty secret, got empty string")
+				}
+				if len(secret) != 64 { // 32 bytes * 2 hex chars
+					t.Errorf("expected hex secret length 64, got %d", len(secret))
+				}
+				// Verify it's valid hex
+				for _, c := range secret {
+					if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+						t.Errorf("expected valid hex characters, got invalid char: %c", c)
+					}
+				}
+			}
+
+			// For generation test, verify file was created
+			if tt.name == "generate_and_persist" {
+				if _, err := os.Stat(testFilePath); err != nil {
+					t.Errorf("expected file to be created at %s, but got error: %v", testFilePath, err)
+				}
+			}
+		})
+	}
+}
+
+func TestGetOrGenerateJWTSecretPersistence(t *testing.T) {
+	// Create temporary directory
+	tmpDir := t.TempDir()
+	testFilePath := filepath.Join(tmpDir, "jwt.secret")
+
+	// First call should generate and persist
+	secret1, err := GetOrGenerateJWTSecretWithPath("", testFilePath)
+	if err != nil {
+		t.Fatalf("first call failed: %v", err)
+	}
+
+	// Second call should return the same secret
+	secret2, err := GetOrGenerateJWTSecretWithPath("", testFilePath)
+	if err != nil {
+		t.Fatalf("second call failed: %v", err)
+	}
+
+	// Secrets should match
+	if secret1 != secret2 {
+		t.Errorf("expected same secret on subsequent calls, got %q then %q", secret1, secret2)
+	}
+
+	// Verify file permissions are restrictive
+	info, err := os.Stat(testFilePath)
+	if err != nil {
+		t.Fatalf("failed to stat file: %v", err)
+	}
+	mode := info.Mode()
+	if mode&0077 != 0 { // Check that group and others have no permissions
+		t.Errorf("expected file permissions 0600, got %o", mode.Perm())
+	}
+}

--- a/device-management/internal/utils/jwt_secret_test.go
+++ b/device-management/internal/utils/jwt_secret_test.go
@@ -128,3 +128,40 @@ func TestGetOrGenerateJWTSecretPersistence(t *testing.T) {
 		t.Errorf("expected file permissions 0600, got %o", mode.Perm())
 	}
 }
+
+func TestGetOrGenerateJWTSecretTrimsWhitespace(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFilePath := filepath.Join(tmpDir, "jwt.secret")
+
+	// Write secret with trailing newline (common with echo command)
+	secretValue := "my-secret-value"
+	if err := os.WriteFile(testFilePath, []byte(secretValue+"\n"), 0600); err != nil {
+		t.Fatalf("failed to setup test file: %v", err)
+	}
+
+	// Should trim and return without newline
+	secret, err := GetOrGenerateJWTSecretWithPath("", testFilePath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if secret != secretValue {
+		t.Errorf("expected %q, got %q (newline not trimmed)", secretValue, secret)
+	}
+}
+
+func TestGetOrGenerateJWTSecretRejectsWhitespaceOnly(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFilePath := filepath.Join(tmpDir, "jwt.secret")
+
+	// Write only whitespace/newlines
+	if err := os.WriteFile(testFilePath, []byte("   \n  \t  \n"), 0600); err != nil {
+		t.Fatalf("failed to setup test file: %v", err)
+	}
+
+	// Should fail because file is whitespace-only
+	_, err := GetOrGenerateJWTSecretWithPath("", testFilePath)
+	if err == nil {
+		t.Errorf("expected error for whitespace-only file, got nil")
+	}
+}


### PR DESCRIPTION
- Automatically generates JWT Token signing secret if not explicitly set
- Saves in /data/jwt.secret to remember the secret between restarts so instance requests dont fail.
- removed env var from env.example
- updated docker-compose.yaml and config.yaml defaults