### PR TITLE
fix(device-management): protocol converter API parity and action erro…

### DIFF
--- a/device-management/api/umh-core/v2/models.proto
+++ b/device-management/api/umh-core/v2/models.proto
@@ -325,7 +325,7 @@ message ProtocolConverterTemplateInfo {
 // ProtocolConverterDFC: Data Flow Component configuration for a protocol converter
 // MUST match umh-core's models.ProtocolConverterDFC exactly
 // (pkg/models/action_models.go:764-769)
-// NOTE: For DeployProtocolConverter, readDfc and writeDfc should be null/empty.
+// NOTE: For DeployProtocolConverter, readDFC and writeDFC should be null/empty.
 // DFC configurations are added later via EditProtocolConverter action.
 message ProtocolConverterDFC {
   // Pipeline processor configuration
@@ -349,8 +349,8 @@ message ProtocolConverter {
   string name = 2; // Bridge name (required)
   ProtocolConverterConnection connection = 3; // Connection details (required: IP + Port)
   map<int32, string> location = 4; // Hierarchical location (level → name)
-  ProtocolConverterDFC readDfc = 5; // Read data flow component (optional)
-  ProtocolConverterDFC writeDfc = 6; // Write data flow component (optional)
+  ProtocolConverterDFC readDFC = 5; // Read data flow component (optional)
+  ProtocolConverterDFC writeDFC = 6; // Write data flow component (optional)
   ProtocolConverterTemplateInfo templateInfo = 7; // Template variables (optional)
   ProtocolConverterMeta meta = 8; // Metadata (optional)
 }

--- a/device-management/bruno/02-ProtocolConverters/01-DeployProtocolConverter.bru
+++ b/device-management/bruno/02-ProtocolConverters/01-DeployProtocolConverter.bru
@@ -40,8 +40,8 @@ docs {
   - name: Display name for the converter (required)
   - connection: Connection details with ip and port (required)
   - location: Hierarchical location mapping (optional)
-  - readDfc: Read data flow component configuration (optional)
-  - writeDfc: Write data flow component configuration (optional)
+  - readDFC: Read data flow component configuration (optional)
+  - writeDFC: Write data flow component configuration (optional)
   - templateInfo: Template variables and configuration (optional)
   - meta: Metadata (optional)
   

--- a/device-management/bruno/02-ProtocolConverters/04-EditProtocolConverter.bru
+++ b/device-management/bruno/02-ProtocolConverters/04-EditProtocolConverter.bru
@@ -45,8 +45,8 @@ docs {
   - name: Updated display name (optional)
   - connection: Updated connection details with ip and port (optional)
   - location: Updated hierarchical location (optional)
-  - readDfc: Updated read data flow component (optional)
-  - writeDfc: Updated write data flow component (optional)
+  - readDFC: Updated read data flow component (optional)
+  - writeDFC: Updated write data flow component (optional)
   - templateInfo: Updated template variables (optional)
   - meta: Updated metadata (optional)
   

--- a/device-management/internal/biz/instance.go
+++ b/device-management/internal/biz/instance.go
@@ -940,6 +940,14 @@ func (uc *InstanceUsecase) correlateResponseByTraceId(ctx context.Context, devic
 							}
 						}
 					}
+					// umh-core SendActionReplyV2 also populates actionReplyPayloadV2.message; match correlateResponseByActionUUID
+					if errorMessage == "" {
+						if v2, ok := payload["actionReplyPayloadV2"].(map[string]interface{}); ok {
+							if msg, ok := v2["message"].(string); ok {
+								errorMessage = msg
+							}
+						}
+					}
 				} else if state == "action-success" {
 					finalStatus = models.ActionStatusCompleted
 				}
@@ -960,9 +968,15 @@ func (uc *InstanceUsecase) correlateResponseByTraceId(ctx context.Context, devic
 	}
 
 	// Store error message in action for retrieval (for both FAILED and FAILED_PARSING_RESPONSE)
-	if (finalStatus == models.ActionStatusFailed || finalStatus == models.ActionStatusFailedParsingResponse) && errorMessage != "" {
-		if err := uc.store.Actions().UpdateErrorMessage(ctx, tenantID, track.ActionID, errorMessage); err != nil {
-			fmt.Printf("Warning: Failed to store error message: %v\n", err)
+	if finalStatus == models.ActionStatusFailed || finalStatus == models.ActionStatusFailedParsingResponse {
+		msg := errorMessage
+		if msg == "" && finalStatus == models.ActionStatusFailed {
+			msg = "Action failed on device, but no error text was found in the reply payload. Check umh-core communicator logs on the edge."
+		}
+		if msg != "" {
+			if err := uc.store.Actions().UpdateErrorMessage(ctx, tenantID, track.ActionID, msg); err != nil {
+				fmt.Printf("Warning: Failed to store error message: %v\n", err)
+			}
 		}
 	}
 
@@ -1047,10 +1061,21 @@ func (uc *InstanceUsecase) correlateResponseByActionUUID(ctx context.Context, te
 					stateFound = true
 					if state == "action-failure" {
 						finalStatus = models.ActionStatusFailed
-						// Extract error message from actionReplyPayloadV2
+						// Prefer structured V2; fall back to legacy actionReplyPayload (string or {message})
 						if payloadV2, ok := payload["actionReplyPayloadV2"].(map[string]interface{}); ok {
 							if msg, ok := payloadV2["message"].(string); ok {
 								errorMessage = msg
+							}
+						}
+						if errorMessage == "" {
+							if replyPayload, ok := payload["actionReplyPayload"]; ok {
+								if msg, ok := replyPayload.(string); ok {
+									errorMessage = msg
+								} else if replyMap, ok := replyPayload.(map[string]interface{}); ok {
+									if msg, ok := replyMap["message"].(string); ok {
+										errorMessage = msg
+									}
+								}
 							}
 						}
 					} else if state == "action-success" {
@@ -1074,9 +1099,15 @@ func (uc *InstanceUsecase) correlateResponseByActionUUID(ctx context.Context, te
 	}
 
 	// Store error message if action failed or parse failed
-	if (finalStatus == models.ActionStatusFailed || finalStatus == models.ActionStatusFailedParsingResponse) && errorMessage != "" {
-		if err := uc.store.Actions().UpdateErrorMessage(ctx, tenantID, action.Id, errorMessage); err != nil {
-			fmt.Printf("Warning: Failed to store error message: %v\n", err)
+	if finalStatus == models.ActionStatusFailed || finalStatus == models.ActionStatusFailedParsingResponse {
+		msg := errorMessage
+		if msg == "" && finalStatus == models.ActionStatusFailed {
+			msg = "Action failed on device, but no error text was found in the reply payload. Check umh-core communicator logs on the edge."
+		}
+		if msg != "" {
+			if err := uc.store.Actions().UpdateErrorMessage(ctx, tenantID, action.Id, msg); err != nil {
+				fmt.Printf("Warning: Failed to store error message: %v\n", err)
+			}
 		}
 	}
 
@@ -1379,8 +1410,8 @@ func (uc *InstanceUsecase) syncProtocolConverterActionResult(ctx context.Context
 			if converterType == "protocol-converter" && action.Payload != nil {
 				var requestPayload map[string]interface{}
 				if err := json.Unmarshal(action.Payload.Value, &requestPayload); err == nil {
-					if readDfc, ok := requestPayload["readDfc"].(map[string]interface{}); ok {
-						if inputs, ok := readDfc["inputs"].(map[string]interface{}); ok {
+					if readDFC, ok := requestPayload["readDFC"].(map[string]interface{}); ok {
+						if inputs, ok := readDFC["inputs"].(map[string]interface{}); ok {
 							if inputType, ok := inputs["type"].(string); ok && inputType != "" {
 								converterType = inputType
 							}
@@ -1434,8 +1465,8 @@ func (uc *InstanceUsecase) syncProtocolConverterActionResult(ctx context.Context
 				if converterType == "protocol-converter" && action.Payload != nil {
 					var requestPayload map[string]interface{}
 					if err := json.Unmarshal(action.Payload.Value, &requestPayload); err == nil {
-						if readDfc, ok := requestPayload["readDfc"].(map[string]interface{}); ok {
-							if inputs, ok := readDfc["inputs"].(map[string]interface{}); ok {
+						if readDFC, ok := requestPayload["readDFC"].(map[string]interface{}); ok {
+							if inputs, ok := readDFC["inputs"].(map[string]interface{}); ok {
 								if inputType, ok := inputs["type"].(string); ok && inputType != "" {
 									converterType = inputType
 								}

--- a/device-management/internal/biz/instance.go
+++ b/device-management/internal/biz/instance.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -85,6 +86,77 @@ func decompressIfNeeded(data []byte) ([]byte, error) {
 
 	// Not compressed, return as-is
 	return data, nil
+}
+
+// actionFailedFallbackMessage is persisted when umh-core reports action-failure without parseable text.
+const actionFailedFallbackMessage = "Action failed on device, but no error text was found in the reply payload. Check umh-core communicator logs on the edge."
+
+// extractActionFailureMessageFromReplyPayload extracts human-readable failure text from a decoded action-reply
+// Payload map (same shape for trace_id and action-UUID correlation).
+// Canonical order (single place — both correlation paths use this): structured actionReplyPayloadV2.message from
+// umh-core SendActionReplyV2, then legacy actionReplyPayload (string or {message}). When V2 exposes a non-empty
+// errorCode string, it is appended as " [<code>]" after the message.
+func extractActionFailureMessageFromReplyPayload(payload map[string]interface{}) string {
+	if payload == nil {
+		return ""
+	}
+	if v2, ok := payload["actionReplyPayloadV2"].(map[string]interface{}); ok {
+		if m, ok := v2["message"].(string); ok {
+			msg := strings.TrimSpace(m)
+			if msg != "" {
+				code := jsonMapString(v2["errorCode"])
+				if code != "" {
+					return msg + " [" + code + "]"
+				}
+				return msg
+			}
+		}
+	}
+	if replyPayload, ok := payload["actionReplyPayload"]; ok {
+		if s, ok := replyPayload.(string); ok {
+			msg := strings.TrimSpace(s)
+			if msg != "" {
+				return msg
+			}
+		}
+		if replyMap, ok := replyPayload.(map[string]interface{}); ok {
+			if m, ok := replyMap["message"].(string); ok {
+				msg := strings.TrimSpace(m)
+				if msg != "" {
+					return msg
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func jsonMapString(v interface{}) string {
+	if v == nil {
+		return ""
+	}
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(s)
+}
+
+// persistActionErrorMessageIfFailed stores error_message for terminal failure statuses (shared by correlateResponseByTraceId and correlateResponseByActionUUID).
+func (uc *InstanceUsecase) persistActionErrorMessageIfFailed(ctx context.Context, tenantID, actionID string, finalStatus models.ActionStatus, errorMessage string) {
+	if finalStatus != models.ActionStatusFailed && finalStatus != models.ActionStatusFailedParsingResponse {
+		return
+	}
+	msg := errorMessage
+	if msg == "" && finalStatus == models.ActionStatusFailed {
+		msg = actionFailedFallbackMessage
+	}
+	if msg == "" {
+		return
+	}
+	if err := uc.store.Actions().UpdateErrorMessage(ctx, tenantID, actionID, msg); err != nil {
+		fmt.Printf("Warning: Failed to store error message: %v\n", err)
+	}
 }
 
 // InstanceUsecase handles device-facing operations: authentication, message polling, and status reporting.
@@ -928,26 +1000,7 @@ func (uc *InstanceUsecase) correlateResponseByTraceId(ctx context.Context, devic
 				stateFound = true
 				if state == "action-failure" {
 					finalStatus = models.ActionStatusFailed
-					// Extract error message from actionReplyPayload (can be string or object)
-					if replyPayload, ok := payload["actionReplyPayload"]; ok {
-						// Try as string first
-						if msg, ok := replyPayload.(string); ok {
-							errorMessage = msg
-						} else if replyMap, ok := replyPayload.(map[string]interface{}); ok {
-							// Try as object with message field
-							if msg, ok := replyMap["message"].(string); ok {
-								errorMessage = msg
-							}
-						}
-					}
-					// umh-core SendActionReplyV2 also populates actionReplyPayloadV2.message; match correlateResponseByActionUUID
-					if errorMessage == "" {
-						if v2, ok := payload["actionReplyPayloadV2"].(map[string]interface{}); ok {
-							if msg, ok := v2["message"].(string); ok {
-								errorMessage = msg
-							}
-						}
-					}
+					errorMessage = extractActionFailureMessageFromReplyPayload(payload)
 				} else if state == "action-success" {
 					finalStatus = models.ActionStatusCompleted
 				}
@@ -967,18 +1020,7 @@ func (uc *InstanceUsecase) correlateResponseByTraceId(ctx context.Context, devic
 		return fmt.Errorf("failed to update action status: %w", err)
 	}
 
-	// Store error message in action for retrieval (for both FAILED and FAILED_PARSING_RESPONSE)
-	if finalStatus == models.ActionStatusFailed || finalStatus == models.ActionStatusFailedParsingResponse {
-		msg := errorMessage
-		if msg == "" && finalStatus == models.ActionStatusFailed {
-			msg = "Action failed on device, but no error text was found in the reply payload. Check umh-core communicator logs on the edge."
-		}
-		if msg != "" {
-			if err := uc.store.Actions().UpdateErrorMessage(ctx, tenantID, track.ActionID, msg); err != nil {
-				fmt.Printf("Warning: Failed to store error message: %v\n", err)
-			}
-		}
-	}
+	uc.persistActionErrorMessageIfFailed(ctx, tenantID, track.ActionID, finalStatus, errorMessage)
 
 	// 6. Sync protocol converter and data model state if action completed
 	// Use RESULT payload from device (resultPayload), not the REQUEST payload (action.Payload)
@@ -1039,15 +1081,15 @@ func (uc *InstanceUsecase) correlateResponseByActionUUID(ctx context.Context, te
 	}
 
 	// Get the message content to extract actionReplyState and error info
-	msg, err := uc.store.Messages().GetByID(ctx, messageID)
+	deviceMsg, err := uc.store.Messages().GetByID(ctx, messageID)
 	finalStatus := models.ActionStatusCompleted
 	errorMessage := ""
 	stateFound := false
 
-	if err == nil && msg != nil {
+	if err == nil && deviceMsg != nil {
 		// Parse message to extract state and error details
-		decodedPayload := msg.Content
-		if decoded, err := base64.StdEncoding.DecodeString(msg.Content); err == nil {
+		decodedPayload := deviceMsg.Content
+		if decoded, err := base64.StdEncoding.DecodeString(deviceMsg.Content); err == nil {
 			decodedPayload = string(decoded)
 		}
 		if decompressed, err := decompressIfNeeded([]byte(decodedPayload)); err == nil {
@@ -1061,23 +1103,7 @@ func (uc *InstanceUsecase) correlateResponseByActionUUID(ctx context.Context, te
 					stateFound = true
 					if state == "action-failure" {
 						finalStatus = models.ActionStatusFailed
-						// Prefer structured V2; fall back to legacy actionReplyPayload (string or {message})
-						if payloadV2, ok := payload["actionReplyPayloadV2"].(map[string]interface{}); ok {
-							if msg, ok := payloadV2["message"].(string); ok {
-								errorMessage = msg
-							}
-						}
-						if errorMessage == "" {
-							if replyPayload, ok := payload["actionReplyPayload"]; ok {
-								if msg, ok := replyPayload.(string); ok {
-									errorMessage = msg
-								} else if replyMap, ok := replyPayload.(map[string]interface{}); ok {
-									if msg, ok := replyMap["message"].(string); ok {
-										errorMessage = msg
-									}
-								}
-							}
-						}
+						errorMessage = extractActionFailureMessageFromReplyPayload(payload)
 					} else if state == "action-success" {
 						finalStatus = models.ActionStatusCompleted
 					}
@@ -1098,31 +1124,26 @@ func (uc *InstanceUsecase) correlateResponseByActionUUID(ctx context.Context, te
 		return fmt.Errorf("failed to update action status: %w", err)
 	}
 
-	// Store error message if action failed or parse failed
-	if finalStatus == models.ActionStatusFailed || finalStatus == models.ActionStatusFailedParsingResponse {
-		msg := errorMessage
-		if msg == "" && finalStatus == models.ActionStatusFailed {
-			msg = "Action failed on device, but no error text was found in the reply payload. Check umh-core communicator logs on the edge."
-		}
-		if msg != "" {
-			if err := uc.store.Actions().UpdateErrorMessage(ctx, tenantID, action.Id, msg); err != nil {
-				fmt.Printf("Warning: Failed to store error message: %v\n", err)
-			}
-		}
-	}
+	uc.persistActionErrorMessageIfFailed(ctx, tenantID, action.Id, finalStatus, errorMessage)
 
 	// 6. Sync state if this is a protocol converter or data model action
 	// This mirrors the logic in correlateResponseByTraceId to ensure DB persistence
 	// regardless of which correlation method (trace_id vs actionUUID) is used
 	if finalStatus == models.ActionStatusCompleted && action != nil {
-		msg, err := uc.store.Messages().GetByID(ctx, messageID)
-		if err == nil && msg != nil {
+		syncMsg := deviceMsg
+		if syncMsg == nil {
+			syncMsg, err = uc.store.Messages().GetByID(ctx, messageID)
+			if err != nil {
+				syncMsg = nil
+			}
+		}
+		if syncMsg != nil {
 			// Create a copy of action with updated status for sync
 			actionWithStatus := *action
 			actionWithStatus.Status = finalStatus
-			_ = uc.syncProtocolConverterActionResult(ctx, &actionWithStatus, []byte(msg.Content))
-			_ = uc.syncDataModelActionResult(ctx, &actionWithStatus, []byte(msg.Content))
-			_ = uc.syncStreamProcessorActionResult(ctx, &actionWithStatus, []byte(msg.Content))
+			_ = uc.syncProtocolConverterActionResult(ctx, &actionWithStatus, []byte(syncMsg.Content))
+			_ = uc.syncDataModelActionResult(ctx, &actionWithStatus, []byte(syncMsg.Content))
+			_ = uc.syncStreamProcessorActionResult(ctx, &actionWithStatus, []byte(syncMsg.Content))
 		}
 	}
 

--- a/device-management/internal/biz/instance_test.go
+++ b/device-management/internal/biz/instance_test.go
@@ -200,3 +200,57 @@ func TestDecompressIfNeededGzip(t *testing.T) {
 		t.Errorf("Data should be decompressed correctly")
 	}
 }
+
+func TestExtractActionFailureMessageFromReplyPayload(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		payload  map[string]interface{}
+		expected string
+	}{
+		{
+			name: "v2 message with errorCode",
+			payload: map[string]interface{}{
+				"actionReplyPayloadV2": map[string]interface{}{
+					"message":   "boom",
+					"errorCode": "E42",
+				},
+			},
+			expected: "boom [E42]",
+		},
+		{
+			name: "v2 preferred over legacy when both present",
+			payload: map[string]interface{}{
+				"actionReplyPayloadV2": map[string]interface{}{"message": "from-v2"},
+				"actionReplyPayload":   "from-legacy",
+			},
+			expected: "from-v2",
+		},
+		{
+			name:     "legacy string",
+			payload:  map[string]interface{}{"actionReplyPayload": "legacy-text"},
+			expected: "legacy-text",
+		},
+		{
+			name: "legacy object message",
+			payload: map[string]interface{}{
+				"actionReplyPayload": map[string]interface{}{"message": "nested"},
+			},
+			expected: "nested",
+		},
+		{
+			name:     "nil payload",
+			payload:  nil,
+			expected: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := extractActionFailureMessageFromReplyPayload(tt.payload)
+			if got != tt.expected {
+				t.Errorf("got %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}

--- a/device-management/internal/service/devicemgmt.go
+++ b/device-management/internal/service/devicemgmt.go
@@ -866,7 +866,7 @@ func (s *DeviceMgmtService) EditProtocolConverter(ctx context.Context, req *v1.E
 	// At least one field must be provided for editing (besides uuid)
 	// Note: All fields except UUID are optional for partial updates
 	if req.Payload.Name == "" && req.Payload.Connection == nil &&
-		req.Payload.ReadDfc == nil && req.Payload.WriteDfc == nil &&
+		req.Payload.ReadDFC == nil && req.Payload.WriteDFC == nil &&
 		req.Payload.TemplateInfo == nil && req.Payload.Meta == nil &&
 		len(req.Payload.Location) == 0 {
 		return nil, status.Error(codes.InvalidArgument,

--- a/device-management/internal/storage/postgres/action.go
+++ b/device-management/internal/storage/postgres/action.go
@@ -66,11 +66,13 @@ func (s *ActionStore) GetByID(ctx context.Context, tenantID, id string) (*models
 	var payloadType, payloadData string
 	var status int32
 	var createdAt, expiresAt, deliveredAt, completedAt sql.NullString
+	var errorMessage sql.NullString
 
 	row := s.db.QueryRowContext(ctx,
 		`SELECT id, device_id, action_type, payload_type, payload_data,
 		        max_retries, retry_count, status,
-		        created_at, expires_at, delivered_at, completed_at
+		        created_at, expires_at, delivered_at, completed_at,
+		        error_message
 		 FROM actions WHERE tenant_id = $1 AND id = $2`, tenantID, id)
 
 	err := row.Scan(
@@ -78,6 +80,7 @@ func (s *ActionStore) GetByID(ctx context.Context, tenantID, id string) (*models
 		&payloadType, &payloadData,
 		&action.MaxRetries, &action.RetryCount, &status,
 		&createdAt, &expiresAt, &deliveredAt, &completedAt,
+		&errorMessage,
 	)
 
 	if err == sql.ErrNoRows {
@@ -114,6 +117,9 @@ func (s *ActionStore) GetByID(ctx context.Context, tenantID, id string) (*models
 	if completedAt.Valid {
 		t, _ := time.Parse(time.RFC3339, completedAt.String)
 		action.CompletedAt = t
+	}
+	if errorMessage.Valid {
+		action.ErrorMessage = errorMessage.String
 	}
 
 	return action, nil
@@ -175,7 +181,8 @@ func (s *ActionStore) ListForDevice(ctx context.Context, deviceID string, filter
 
 	query := fmt.Sprintf(`SELECT id, device_id, action_type, payload_type, payload_data,
 		max_retries, retry_count, status,
-		created_at, expires_at, delivered_at, completed_at
+		created_at, expires_at, delivered_at, completed_at,
+		error_message
 		FROM actions %s ORDER BY %s
 		LIMIT $%d OFFSET $%d`,
 		whereClause, orderBy, paramCounter, paramCounter+1)
@@ -194,12 +201,14 @@ func (s *ActionStore) ListForDevice(ctx context.Context, deviceID string, filter
 		var payloadType, payloadData string
 		var status int32
 		var createdAt, expiresAt, deliveredAt, completedAt sql.NullString
+		var errorMessage sql.NullString
 
 		err := rows.Scan(
 			&action.Id, &action.DeviceId, &action.Type,
 			&payloadType, &payloadData,
 			&action.MaxRetries, &action.RetryCount, &status,
 			&createdAt, &expiresAt, &deliveredAt, &completedAt,
+			&errorMessage,
 		)
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to scan action: %w", err)
@@ -231,6 +240,9 @@ func (s *ActionStore) ListForDevice(ctx context.Context, deviceID string, filter
 		if completedAt.Valid {
 			t, _ := time.Parse(time.RFC3339, completedAt.String)
 			action.CompletedAt = t
+		}
+		if errorMessage.Valid {
+			action.ErrorMessage = errorMessage.String
 		}
 
 		actions = append(actions, action)
@@ -433,7 +445,8 @@ func (s *ActionStore) listActions(ctx context.Context, whereClause string, args 
 	query := `
 	SELECT id, device_id, action_type, payload_type, payload_data,
 	       max_retries, retry_count, status,
-	       created_at, expires_at, delivered_at, completed_at
+	       created_at, expires_at, delivered_at, completed_at,
+	       error_message
 	FROM actions ` + whereClause
 
 	rows, err := s.db.QueryContext(ctx, query, args...)
@@ -448,12 +461,14 @@ func (s *ActionStore) listActions(ctx context.Context, whereClause string, args 
 		var payloadType, payloadData string
 		var status int32
 		var createdAt, expiresAt, deliveredAt, completedAt sql.NullString
+		var errorMessage sql.NullString
 
 		err := rows.Scan(
 			&action.Id, &action.DeviceId, &action.Type,
 			&payloadType, &payloadData,
 			&action.MaxRetries, &action.RetryCount, &status,
 			&createdAt, &expiresAt, &deliveredAt, &completedAt,
+			&errorMessage,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan action: %w", err)
@@ -485,6 +500,9 @@ func (s *ActionStore) listActions(ctx context.Context, whereClause string, args 
 		if completedAt.Valid {
 			t, _ := time.Parse(time.RFC3339, completedAt.String)
 			action.CompletedAt = t
+		}
+		if errorMessage.Valid {
+			action.ErrorMessage = errorMessage.String
 		}
 
 		actions = append(actions, action)

--- a/device-management/openapi.yaml
+++ b/device-management/openapi.yaml
@@ -2208,9 +2208,9 @@ components:
                     type: object
                     additionalProperties:
                         type: string
-                readDfc:
+                readDFC:
                     $ref: '#/components/schemas/api.umh_core.v2.ProtocolConverterDFC'
-                writeDfc:
+                writeDFC:
                     $ref: '#/components/schemas/api.umh_core.v2.ProtocolConverterDFC'
                 templateInfo:
                     $ref: '#/components/schemas/api.umh_core.v2.ProtocolConverterTemplateInfo'
@@ -2254,7 +2254,7 @@ components:
                 ProtocolConverterDFC: Data Flow Component configuration for a protocol converter
                  MUST match umh-core's models.ProtocolConverterDFC exactly
                  (pkg/models/action_models.go:764-769)
-                 NOTE: For DeployProtocolConverter, readDfc and writeDfc should be null/empty.
+                 NOTE: For DeployProtocolConverter, readDFC and writeDFC should be null/empty.
                  DFC configurations are added later via EditProtocolConverter action.
         api.umh_core.v2.ProtocolConverterMeta:
             type: object


### PR DESCRIPTION
…r surfacing

- Rename ProtocolConverter proto fields to readDFC/writeDFC so JSON matches umh-core and encoding/json payloads queue correctly to the edge.
- Align EditProtocolConverter validation and protocol-converter deploy/edit sync paths with the new wire keys; refresh Bruno/OpenAPI artifacts.
- When correlating action-reply pushes, read failure text from actionReplyPayloadV2.message as well as legacy actionReplyPayload, mirror fallbacks on trace vs action-UUID paths, and persist a short default if the device omits parseable text.
- Load actions.error_message from Postgres in GetByID and list helpers so GetProtocolConverterActionResponse returns the full message after FAILED.