### PR TITLE
feat(device-management): enrich /devices/{device_id}/health with safe status…

### DIFF
--- a/device-management/api/devicemgmt/v1/devicemgmt.proto
+++ b/device-management/api/devicemgmt/v1/devicemgmt.proto
@@ -463,14 +463,69 @@ message GetDeviceHealthRequest {
   string device_id = 1;
 }
 
-// DeviceHealthResponse contains health metrics from latest Push API data
+message DeviceCoreHealthSummary {
+  string message       = 1;
+  string state         = 2;
+  string desired_state = 3 [json_name = "desired_state"];
+  // Category: "active" | "degraded" | "neutral"
+  string category      = 4;
+}
+
+message DeviceAgentLatencySummary {
+  double avg_ms = 1 [json_name = "avg_ms"];
+  double max_ms = 2 [json_name = "max_ms"];
+  double min_ms = 3 [json_name = "min_ms"];
+  double p95_ms = 4 [json_name = "p95_ms"];
+  double p99_ms = 5 [json_name = "p99_ms"];
+}
+
+message DeviceResourcesSummary {
+  // CPU
+  double cpu_total_usage_m_cpu = 1 [json_name = "cpu_total_usage_m_cpu"];
+  int32  cpu_core_count        = 2 [json_name = "cpu_core_count"];
+  double cpu_cgroup_cores      = 3 [json_name = "cpu_cgroup_cores"];
+  double cpu_throttle_ratio    = 4 [json_name = "cpu_throttle_ratio"];
+  bool   cpu_is_throttled      = 5 [json_name = "cpu_is_throttled"];
+
+  // Memory / Disk
+  int64 memory_used_bytes  = 6 [json_name = "memory_used_bytes"];
+  int64 memory_total_bytes = 7 [json_name = "memory_total_bytes"];
+  int64 disk_used_bytes    = 8 [json_name = "disk_used_bytes"];
+  int64 disk_total_bytes   = 9 [json_name = "disk_total_bytes"];
+
+  // Hardware / runtime info
+  string hwid         = 10;
+  string architecture = 11;
+}
+
+message DeviceReleaseSummary {
+  string version = 1;
+  string channel = 2;
+}
+
+// DeviceHealthResponse contains health metrics from latest Push API data.
+// This endpoint is intentionally summary-only: it avoids returning the full device StatusMessage payload
+// (which may include large blobs like UNS bundles, or detailed per-component inventories).
 message DeviceHealthResponse {
   string                        device_id        = 1;
-  google.protobuf.Timestamp     last_updated     = 2; // When health data was last received from device
-  api.umh_core.v2.StatusMessage status           = 3; // Complete device status from Push API
-  string                        status_b64       = 4; // Base64-encoded StatusMessage (fallback if status fails to unmarshal)
+  // Last time the device communicated with device-management (Pull heartbeat).
+  // Note: this replaces the former last_updated field (same tag = 2).
+  google.protobuf.Timestamp     last_seen        = 2 [json_name = "last_seen"];
+  // Deprecated: intentionally not populated by server to keep /health summary-only.
+  api.umh_core.v2.StatusMessage status           = 3;
+  // Deprecated: intentionally not populated by server to keep /health summary-only.
+  string                        status_b64       = 4;
   google.protobuf.Timestamp     device_timestamp = 5; // Device's own timestamp from status message
   string                        error_message    = 6; // Error message if health data unavailable
+  // Effective device status derived from last_seen (ACTIVE/INACTIVE), matching ListDevices.
+  DeviceStatus                  device_status    = 8;
+  // Latest device-reported health summaries (when the device sends StatusMessage heartbeats)
+  DeviceCoreHealthSummary       core_health      = 9 [json_name = "core_health"];
+  DeviceAgentLatencySummary     agent_latency    = 10 [json_name = "agent_latency"];
+  DeviceResourcesSummary        resources        = 11;
+  DeviceReleaseSummary          release          = 12;
+
+  reserved 7, 13;
 }
 
 // UpdateDeviceRequest updates device information

--- a/device-management/api/devicemgmt/v1/devicemgmt.proto
+++ b/device-management/api/devicemgmt/v1/devicemgmt.proto
@@ -510,22 +510,18 @@ message DeviceHealthResponse {
   string                        device_id        = 1;
   // Last time the device communicated with device-management (Pull heartbeat).
   // Note: this replaces the former last_updated field (same tag = 2).
-  google.protobuf.Timestamp     last_seen        = 2 [json_name = "last_seen"];
-  // Deprecated: intentionally not populated by server to keep /health summary-only.
-  api.umh_core.v2.StatusMessage status           = 3;
-  // Deprecated: intentionally not populated by server to keep /health summary-only.
-  string                        status_b64       = 4;
+  google.protobuf.Timestamp     last_seen        = 2;
   google.protobuf.Timestamp     device_timestamp = 5; // Device's own timestamp from status message
   string                        error_message    = 6; // Error message if health data unavailable
   // Effective device status derived from last_seen (ACTIVE/INACTIVE), matching ListDevices.
   DeviceStatus                  device_status    = 8;
   // Latest device-reported health summaries (when the device sends StatusMessage heartbeats)
-  DeviceCoreHealthSummary       core_health      = 9 [json_name = "core_health"];
-  DeviceAgentLatencySummary     agent_latency    = 10 [json_name = "agent_latency"];
+  DeviceCoreHealthSummary       core_health      = 9;
+  DeviceAgentLatencySummary     agent_latency    = 10;
   DeviceResourcesSummary        resources        = 11;
   DeviceReleaseSummary          release          = 12;
 
-  reserved 7, 13;
+  reserved 3, 4, 7, 13;
 }
 
 // UpdateDeviceRequest updates device information

--- a/device-management/db/schema.postgres.sql
+++ b/device-management/db/schema.postgres.sql
@@ -110,6 +110,12 @@ CREATE INDEX IF NOT EXISTS idx_actions_device_status ON actions(device_id, statu
 CREATE INDEX IF NOT EXISTS idx_actions_tenant_status ON actions(tenant_id, status);
 CREATE INDEX IF NOT EXISTS idx_actions_tenant_device ON actions(tenant_id, device_id);
 
+-- Idempotency for edge status subscription: at most one QUEUED subscribe action per device+tenant.
+-- This supports running multiple device-management replicas without enqueueing duplicate subscribe actions.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_actions_subscribe_queued
+  ON actions(tenant_id, device_id, action_type)
+  WHERE action_type = 'subscribe' AND status = 1;
+
 -- Messages table: Stores message history for auditing and debugging
 CREATE TABLE IF NOT EXISTS messages (
   id TEXT PRIMARY KEY,

--- a/device-management/internal/biz/device.go
+++ b/device-management/internal/biz/device.go
@@ -16,6 +16,7 @@ import (
 	"github.com/artpark-hub/taksa-platform/device-management/internal/middleware"
 	"github.com/artpark-hub/taksa-platform/device-management/internal/pkg/cert"
 	"github.com/artpark-hub/taksa-platform/device-management/internal/storage"
+	"github.com/artpark-hub/taksa-platform/device-management/internal/utils"
 )
 
 // DeviceUsecase handles device business logic (registration, listing, updates)
@@ -166,23 +167,10 @@ func (uc *DeviceUsecase) GetDeviceHealth(ctx context.Context, deviceID string) (
 	if err != nil {
 		return nil, fmt.Errorf("device not found: %w", err)
 	}
-	effectiveStatus := deriveEffectiveDeviceStatus(device)
+	effectiveStatus := utils.DeriveEffectiveDeviceStatus(device, deviceActiveWindow)
 
-	// Get the latest message (any type) to determine if device is communicating
-	// The Pull API heartbeat updates last_seen timestamp regularly
-	// The Push API sends action-reply and other messages
-	filter := &storage.MessageListFilter{
-		DeviceID: deviceID,
-		PageSize: 25,
-		SortDesc: true, // Most recent first
-	}
-
-	messages, _, err := uc.store.Messages().ListHistory(ctx, filter)
-	listErr := err
-	if listErr != nil {
-		// Non-fatal: health summary will degrade to device snapshot + last_seen based messaging.
-		messages = nil
-	}
+	// Get recent messages (avoid ListHistory COUNT query; health only needs latest N)
+	messages, listErr := uc.store.Messages().GetRecentByDevice(ctx, deviceID, 25)
 
 	// Build response based on device's current state
 	resp := &GetDeviceHealthResponse{
@@ -190,8 +178,6 @@ func (uc *DeviceUsecase) GetDeviceHealth(ctx context.Context, deviceID string) (
 		DeviceStatus: effectiveStatus,
 		LastSeen:    device.LastSeen, // Use device's last_seen from Pull API heartbeat
 		// /health is intentionally summary-only; we do not surface full StatusMessage payloads here.
-		Status:    nil,
-		StatusB64: "",
 	}
 	if listErr != nil {
 		resp.ErrorMessage = "failed to load device message history for status heartbeat"
@@ -249,38 +235,6 @@ func (uc *DeviceUsecase) GetDeviceHealth(ctx context.Context, deviceID string) (
 	return resp, nil
 }
 
-// deriveEffectiveDeviceStatus mirrors the device listing rule used by ListDevices:
-// - PENDING stays PENDING until first login flips it
-// - SUSPENDED/DECOMMISSIONED are terminal admin statuses
-// - ACTIVE/INACTIVE are derived from last_seen within a 1 minute window
-func deriveEffectiveDeviceStatus(device *v1.Device) v1.DeviceStatus {
-	if device == nil {
-		return v1.DeviceStatus_DEVICE_STATUS_UNSPECIFIED
-	}
-
-	switch device.Status {
-	case v1.DeviceStatus_SUSPENDED, v1.DeviceStatus_DECOMMISSIONED:
-		return device.Status
-	case v1.DeviceStatus_PENDING:
-		return v1.DeviceStatus_PENDING
-	default:
-		// Only derive for ACTIVE/INACTIVE/UNSPECIFIED. Preserve any other admin states.
-		if device.Status != v1.DeviceStatus_ACTIVE &&
-			device.Status != v1.DeviceStatus_INACTIVE &&
-			device.Status != v1.DeviceStatus_DEVICE_STATUS_UNSPECIFIED {
-			return device.Status
-		}
-	}
-
-	if device.LastSeen != nil {
-		if time.Since(device.LastSeen.AsTime()) <= deviceActiveWindow {
-			return v1.DeviceStatus_ACTIVE
-		}
-		return v1.DeviceStatus_INACTIVE
-	}
-	return v1.DeviceStatus_INACTIVE
-}
-
 func extractDeviceHealthSummariesFromStatusContent(content string) (*v1.DeviceCoreHealthSummary, *v1.DeviceAgentLatencySummary, *v1.DeviceResourcesSummary, *v1.DeviceReleaseSummary, *timestamppb.Timestamp) {
 	decoded := content
 	if b, err := base64.StdEncoding.DecodeString(content); err == nil && len(b) > 0 {
@@ -291,7 +245,9 @@ func extractDeviceHealthSummariesFromStatusContent(content string) (*v1.DeviceCo
 	}
 
 	var root map[string]interface{}
-	if err := json.Unmarshal([]byte(decoded), &root); err != nil || root == nil {
+	dec := json.NewDecoder(strings.NewReader(decoded))
+	dec.UseNumber()
+	if err := dec.Decode(&root); err != nil || root == nil {
 		return nil, nil, nil, nil, nil
 	}
 
@@ -353,12 +309,12 @@ func extractDeviceHealthSummariesFromStatusContent(content string) (*v1.DeviceCo
 			outResources.CpuIsThrottled = jsonBool(cpu, "isThrottled", "cpu_is_throttled", "IsThrottled")
 		}
 		if mem := jsonMap(container, "memory", "Memory"); mem != nil {
-			outResources.MemoryUsedBytes = int64(jsonFloat(mem, "cGroupUsedBytes", "cgroupUsedBytes", "memory_used_bytes", "CGroupUsedBytes"))
-			outResources.MemoryTotalBytes = int64(jsonFloat(mem, "cGroupTotalBytes", "cgroupTotalBytes", "memory_total_bytes", "CGroupTotalBytes"))
+			outResources.MemoryUsedBytes = jsonInt64(mem, "cGroupUsedBytes", "cgroupUsedBytes", "memory_used_bytes", "CGroupUsedBytes")
+			outResources.MemoryTotalBytes = jsonInt64(mem, "cGroupTotalBytes", "cgroupTotalBytes", "memory_total_bytes", "CGroupTotalBytes")
 		}
 		if disk := jsonMap(container, "disk", "Disk"); disk != nil {
-			outResources.DiskUsedBytes = int64(jsonFloat(disk, "dataPartitionUsedBytes", "disk_used_bytes", "DataPartitionUsedBytes"))
-			outResources.DiskTotalBytes = int64(jsonFloat(disk, "dataPartitionTotalBytes", "disk_total_bytes", "DataPartitionTotalBytes"))
+			outResources.DiskUsedBytes = jsonInt64(disk, "dataPartitionUsedBytes", "disk_used_bytes", "DataPartitionUsedBytes")
+			outResources.DiskTotalBytes = jsonInt64(disk, "dataPartitionTotalBytes", "disk_total_bytes", "DataPartitionTotalBytes")
 		}
 		if outResources.Hwid == "" &&
 			outResources.Architecture == "" &&
@@ -438,6 +394,37 @@ func jsonFloat(m map[string]interface{}, keys ...string) float64 {
 	return 0
 }
 
+func jsonInt64(m map[string]interface{}, keys ...string) int64 {
+	if m == nil {
+		return 0
+	}
+	for _, k := range keys {
+		switch v := m[k].(type) {
+		case int64:
+			return v
+		case int:
+			return int64(v)
+		case int32:
+			return int64(v)
+		case float64:
+			// Best-effort fallback (should be avoided for large integers)
+			return int64(v)
+		case json.Number:
+			if i, err := v.Int64(); err == nil {
+				return i
+			}
+			if f, err := v.Float64(); err == nil {
+				return int64(f)
+			}
+		case string:
+			if i, err := json.Number(v).Int64(); err == nil {
+				return i
+			}
+		}
+	}
+	return 0
+}
+
 func jsonBool(m map[string]interface{}, keys ...string) bool {
 	if m == nil {
 		return false
@@ -455,8 +442,6 @@ type GetDeviceHealthResponse struct {
 	DeviceId        string
 	DeviceStatus    v1.DeviceStatus
 	LastSeen        *timestamppb.Timestamp
-	Status          *v2.StatusMessage
-	StatusB64       string // Base64-encoded StatusMessage fallback
 	DeviceTimestamp *timestamppb.Timestamp
 	ErrorMessage    string
 	CoreHealth      *v1.DeviceCoreHealthSummary

--- a/device-management/internal/biz/device.go
+++ b/device-management/internal/biz/device.go
@@ -2,6 +2,8 @@ package biz
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -23,6 +25,8 @@ type DeviceUsecase struct {
 	baseURL            string
 	umhCoreDockerImage string
 }
+
+const deviceActiveWindow = 1 * time.Minute
 
 // NewDeviceUsecase creates a new device use case
 func NewDeviceUsecase(store storage.Store, authUc *AuthUsecase, baseURL, umhCoreDockerImage string) *DeviceUsecase {
@@ -162,24 +166,35 @@ func (uc *DeviceUsecase) GetDeviceHealth(ctx context.Context, deviceID string) (
 	if err != nil {
 		return nil, fmt.Errorf("device not found: %w", err)
 	}
+	effectiveStatus := deriveEffectiveDeviceStatus(device)
 
 	// Get the latest message (any type) to determine if device is communicating
 	// The Pull API heartbeat updates last_seen timestamp regularly
 	// The Push API sends action-reply and other messages
 	filter := &storage.MessageListFilter{
 		DeviceID: deviceID,
-		PageSize: 1,
+		PageSize: 25,
 		SortDesc: true, // Most recent first
 	}
 
 	messages, _, err := uc.store.Messages().ListHistory(ctx, filter)
+	listErr := err
+	if listErr != nil {
+		// Non-fatal: health summary will degrade to device snapshot + last_seen based messaging.
+		messages = nil
+	}
 
 	// Build response based on device's current state
 	resp := &GetDeviceHealthResponse{
 		DeviceId:    deviceID,
-		LastUpdated: device.LastSeen, // Use device's last_seen from Pull API heartbeat
-		Status:      nil,             // Status message not yet implemented
-		StatusB64:   "",              // Will be populated when Status message is sent
+		DeviceStatus: effectiveStatus,
+		LastSeen:    device.LastSeen, // Use device's last_seen from Pull API heartbeat
+		// /health is intentionally summary-only; we do not surface full StatusMessage payloads here.
+		Status:    nil,
+		StatusB64: "",
+	}
+	if listErr != nil {
+		resp.ErrorMessage = "failed to load device message history for status heartbeat"
 	}
 
 	// Check if device has recent activity (within last 30 seconds)
@@ -198,30 +213,256 @@ func (uc *DeviceUsecase) GetDeviceHealth(ctx context.Context, deviceID string) (
 		resp.ErrorMessage = "no Pull API activity recorded (device may be newly registered)"
 	}
 
-	// If device has sent messages, extract health data if available
-	// Currently looking for status-type messages (future enhancement)
-	if len(messages) > 0 && messages[0] != nil {
-		msg := messages[0]
-
-		// Look for StatusMessage in message content
-		// The Content field contains base64-encoded JSON with the message payload
-		if msg.Content != "" && msg.Type == "StatusMessage" {
-			resp.StatusB64 = msg.Content
-			// TODO: Implement proper protobuf unmarshaling of StatusMessage from Content field
+	// If device has sent messages, extract summary health data from the most recent status heartbeat.
+	// We cannot assume the newest message is a status heartbeat (action-replies may arrive more frequently).
+	foundStatusHeartbeat := false
+	for _, msg := range messages {
+		if msg == nil {
+			continue
+		}
+		if msg.Content == "" {
+			continue
+		}
+		// taksa-edge-umh sends MessageType "status" (not "status-message")
+		if msg.Type != "StatusMessage" && msg.Type != "status-message" && msg.Type != "status" {
+			continue
+		}
+		foundStatusHeartbeat = true
+		core, latency, resources, release, deviceTs := extractDeviceHealthSummariesFromStatusContent(msg.Content)
+		resp.CoreHealth = core
+		resp.AgentLatency = latency
+		resp.Resources = resources
+		resp.Release = release
+		resp.DeviceTimestamp = deviceTs
+		break
+	}
+	if len(messages) > 0 && !foundStatusHeartbeat {
+		// Most likely: device isn't pushing StatusMessage heartbeats into DM (or message_type differs).
+		// Keep endpoint summary-only but make the gap visible to clients/operators.
+		if resp.ErrorMessage == "" {
+			resp.ErrorMessage = "no status heartbeat message found in recent device messages (expected message_type: status/status-message/StatusMessage)"
+		} else {
+			resp.ErrorMessage = resp.ErrorMessage + "; no status heartbeat message found in recent device messages (expected message_type: status/status-message/StatusMessage)"
 		}
 	}
 
 	return resp, nil
 }
 
+// deriveEffectiveDeviceStatus mirrors the device listing rule used by ListDevices:
+// - PENDING stays PENDING until first login flips it
+// - SUSPENDED/DECOMMISSIONED are terminal admin statuses
+// - ACTIVE/INACTIVE are derived from last_seen within a 1 minute window
+func deriveEffectiveDeviceStatus(device *v1.Device) v1.DeviceStatus {
+	if device == nil {
+		return v1.DeviceStatus_DEVICE_STATUS_UNSPECIFIED
+	}
+
+	switch device.Status {
+	case v1.DeviceStatus_SUSPENDED, v1.DeviceStatus_DECOMMISSIONED:
+		return device.Status
+	case v1.DeviceStatus_PENDING:
+		return v1.DeviceStatus_PENDING
+	default:
+		// Only derive for ACTIVE/INACTIVE/UNSPECIFIED. Preserve any other admin states.
+		if device.Status != v1.DeviceStatus_ACTIVE &&
+			device.Status != v1.DeviceStatus_INACTIVE &&
+			device.Status != v1.DeviceStatus_DEVICE_STATUS_UNSPECIFIED {
+			return device.Status
+		}
+	}
+
+	if device.LastSeen != nil {
+		if time.Since(device.LastSeen.AsTime()) <= deviceActiveWindow {
+			return v1.DeviceStatus_ACTIVE
+		}
+		return v1.DeviceStatus_INACTIVE
+	}
+	return v1.DeviceStatus_INACTIVE
+}
+
+func extractDeviceHealthSummariesFromStatusContent(content string) (*v1.DeviceCoreHealthSummary, *v1.DeviceAgentLatencySummary, *v1.DeviceResourcesSummary, *v1.DeviceReleaseSummary, *timestamppb.Timestamp) {
+	decoded := content
+	if b, err := base64.StdEncoding.DecodeString(content); err == nil && len(b) > 0 {
+		decoded = string(b)
+	}
+	if decompressed, err := decompressIfNeeded([]byte(decoded)); err == nil && len(decompressed) > 0 {
+		decoded = string(decompressed)
+	}
+
+	var root map[string]interface{}
+	if err := json.Unmarshal([]byte(decoded), &root); err != nil || root == nil {
+		return nil, nil, nil, nil, nil
+	}
+
+	// The status heartbeat may be either the StatusMessage object itself or a wrapper with "Payload".
+	payload := root
+	if p, ok := root["Payload"].(map[string]interface{}); ok && p != nil {
+		payload = p
+	}
+
+	core := jsonMap(payload, "core", "Core")
+	if core == nil {
+		return nil, nil, nil, nil, nil
+	}
+
+	coreHealth := jsonMap(core, "health", "Health")
+	outCoreHealth := &v1.DeviceCoreHealthSummary{}
+	if coreHealth != nil {
+		outCoreHealth.Message = jsonString(coreHealth, "message", "Message")
+		outCoreHealth.State = jsonString(coreHealth, "state", "State")
+		outCoreHealth.DesiredState = jsonString(coreHealth, "desiredState", "desired_state", "DesiredState")
+		outCoreHealth.Category = jsonString(coreHealth, "category", "Category")
+		if outCoreHealth.Message == "" && outCoreHealth.State == "" && outCoreHealth.DesiredState == "" && outCoreHealth.Category == "" {
+			outCoreHealth = nil
+		}
+	} else {
+		outCoreHealth = nil
+	}
+
+	agent := jsonMap(core, "agent", "Agent")
+	outLatency := (*v1.DeviceAgentLatencySummary)(nil)
+	if agent != nil {
+		lat := jsonMap(agent, "latency", "Latency")
+		if lat != nil {
+			outLatency = &v1.DeviceAgentLatencySummary{
+				AvgMs: jsonFloat(lat, "avgMs", "avg_ms", "AvgMs"),
+				MaxMs: jsonFloat(lat, "maxMs", "max_ms", "MaxMs"),
+				MinMs: jsonFloat(lat, "minMs", "min_ms", "MinMs"),
+				P95Ms: jsonFloat(lat, "p95Ms", "p95_ms", "P95Ms"),
+				P99Ms: jsonFloat(lat, "p99Ms", "p99_ms", "P99Ms"),
+			}
+			if outLatency.AvgMs == 0 && outLatency.MaxMs == 0 && outLatency.MinMs == 0 && outLatency.P95Ms == 0 && outLatency.P99Ms == 0 {
+				outLatency = nil
+			}
+		}
+	}
+
+	container := jsonMap(core, "container", "Container")
+	outResources := (*v1.DeviceResourcesSummary)(nil)
+	if container != nil {
+		outResources = &v1.DeviceResourcesSummary{
+			Hwid:         jsonString(container, "hwid", "Hwid"),
+			Architecture: jsonString(container, "architecture", "Architecture"),
+		}
+		if cpu := jsonMap(container, "cpu", "CPU"); cpu != nil {
+			outResources.CpuTotalUsageMCpu = jsonFloat(cpu, "totalUsageMCpu", "cpu_total_usage_m_cpu", "TotalUsageMCpu")
+			outResources.CpuCoreCount = int32(jsonFloat(cpu, "coreCount", "cpu_core_count", "CoreCount"))
+			outResources.CpuCgroupCores = jsonFloat(cpu, "cgroupCores", "cpu_cgroup_cores", "CgroupCores")
+			outResources.CpuThrottleRatio = jsonFloat(cpu, "throttleRatio", "cpu_throttle_ratio", "ThrottleRatio")
+			outResources.CpuIsThrottled = jsonBool(cpu, "isThrottled", "cpu_is_throttled", "IsThrottled")
+		}
+		if mem := jsonMap(container, "memory", "Memory"); mem != nil {
+			outResources.MemoryUsedBytes = int64(jsonFloat(mem, "cGroupUsedBytes", "cgroupUsedBytes", "memory_used_bytes", "CGroupUsedBytes"))
+			outResources.MemoryTotalBytes = int64(jsonFloat(mem, "cGroupTotalBytes", "cgroupTotalBytes", "memory_total_bytes", "CGroupTotalBytes"))
+		}
+		if disk := jsonMap(container, "disk", "Disk"); disk != nil {
+			outResources.DiskUsedBytes = int64(jsonFloat(disk, "dataPartitionUsedBytes", "disk_used_bytes", "DataPartitionUsedBytes"))
+			outResources.DiskTotalBytes = int64(jsonFloat(disk, "dataPartitionTotalBytes", "disk_total_bytes", "DataPartitionTotalBytes"))
+		}
+		if outResources.Hwid == "" &&
+			outResources.Architecture == "" &&
+			outResources.CpuTotalUsageMCpu == 0 &&
+			outResources.CpuCoreCount == 0 &&
+			outResources.CpuCgroupCores == 0 &&
+			outResources.CpuThrottleRatio == 0 &&
+			!outResources.CpuIsThrottled &&
+			outResources.MemoryUsedBytes == 0 &&
+			outResources.MemoryTotalBytes == 0 &&
+			outResources.DiskUsedBytes == 0 &&
+			outResources.DiskTotalBytes == 0 {
+			outResources = nil
+		}
+	}
+
+	release := jsonMap(core, "release", "Release")
+	outRelease := (*v1.DeviceReleaseSummary)(nil)
+	if release != nil {
+		outRelease = &v1.DeviceReleaseSummary{
+			Version: jsonString(release, "version", "Version"),
+			Channel: jsonString(release, "channel", "Channel"),
+		}
+		if outRelease.Version == "" && outRelease.Channel == "" {
+			outRelease = nil
+		}
+	}
+
+	// DeviceTimestamp: status payload does not currently include an explicit timestamp field in v2.StatusMessage.
+	return outCoreHealth, outLatency, outResources, outRelease, nil
+}
+
+func jsonMap(m map[string]interface{}, keys ...string) map[string]interface{} {
+	if m == nil {
+		return nil
+	}
+	for _, k := range keys {
+		if v, ok := m[k].(map[string]interface{}); ok {
+			return v
+		}
+	}
+	return nil
+}
+
+func jsonString(m map[string]interface{}, keys ...string) string {
+	if m == nil {
+		return ""
+	}
+	for _, k := range keys {
+		if s, ok := m[k].(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+func jsonFloat(m map[string]interface{}, keys ...string) float64 {
+	if m == nil {
+		return 0
+	}
+	for _, k := range keys {
+		switch v := m[k].(type) {
+		case float64:
+			return v
+		case int:
+			return float64(v)
+		case int32:
+			return float64(v)
+		case int64:
+			return float64(v)
+		case json.Number:
+			if f, err := v.Float64(); err == nil {
+				return f
+			}
+		}
+	}
+	return 0
+}
+
+func jsonBool(m map[string]interface{}, keys ...string) bool {
+	if m == nil {
+		return false
+	}
+	for _, k := range keys {
+		if b, ok := m[k].(bool); ok {
+			return b
+		}
+	}
+	return false
+}
+
 // GetDeviceHealthResponse contains health metrics
 type GetDeviceHealthResponse struct {
 	DeviceId        string
-	LastUpdated     *timestamppb.Timestamp
+	DeviceStatus    v1.DeviceStatus
+	LastSeen        *timestamppb.Timestamp
 	Status          *v2.StatusMessage
 	StatusB64       string // Base64-encoded StatusMessage fallback
 	DeviceTimestamp *timestamppb.Timestamp
 	ErrorMessage    string
+	CoreHealth      *v1.DeviceCoreHealthSummary
+	AgentLatency    *v1.DeviceAgentLatencySummary
+	Resources       *v1.DeviceResourcesSummary
+	Release         *v1.DeviceReleaseSummary
 }
 
 // deviceToSummary converts a full Device to a DeviceSummary (lightweight version)

--- a/device-management/internal/biz/instance.go
+++ b/device-management/internal/biz/instance.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -166,6 +167,7 @@ const (
 	subscribeActionType = "subscribe"
 	// subscribeActionDefaultTTLSeconds should be <= edge subscriber TTL to avoid stale subscribe actions piling up.
 	subscribeActionDefaultTTLSeconds int32 = 120
+	subscribeActionPayloadTypeURL          = "type.googleapis.com/taksa.edge.SubscribeMessagePayload"
 )
 
 // EnsureStatusSubscription queues a lightweight "subscribe" action for the device (if not already pending).
@@ -178,6 +180,10 @@ func (uc *InstanceUsecase) EnsureStatusSubscription(ctx context.Context, deviceI
 	if tenantID == "" {
 		return
 	}
+
+	mu := uc.subscribeActionMutex(deviceID)
+	mu.Lock()
+	defer mu.Unlock()
 
 	// Avoid spamming: if there's already a pending subscribe action, don't add another.
 	pending, err := uc.store.Actions().ListPending(ctx, tenantID, deviceID)
@@ -201,7 +207,7 @@ func (uc *InstanceUsecase) EnsureStatusSubscription(ctx context.Context, deviceI
 		Id:         generateUUID(),
 		DeviceId:   deviceID,
 		Type:       subscribeActionType,
-		Payload:    &anypb.Any{Value: payloadJSON},
+		Payload:    &anypb.Any{TypeUrl: subscribeActionPayloadTypeURL, Value: payloadJSON},
 		MaxRetries: 0,
 		RetryCount: 0,
 		Status:     models.ActionStatusQueued,
@@ -221,6 +227,8 @@ type InstanceUsecase struct {
 	protocolConverterRepo *data.ProtocolConverterRepo
 	dataModelRepo         *data.DataModelRepo
 	streamProcessorRepo   *data.StreamProcessorRepo
+
+	subscribeActionLocks sync.Map // map[deviceID]*sync.Mutex
 }
 
 // NewInstanceUsecase creates a new InstanceUsecase with the given storage and authentication backends.
@@ -232,6 +240,18 @@ func NewInstanceUsecase(store storage.Store, authUc *AuthUsecase, protocolConver
 		dataModelRepo:         dataModelRepo,
 		streamProcessorRepo:   streamProcessorRepo,
 	}
+}
+
+func (uc *InstanceUsecase) subscribeActionMutex(deviceID string) *sync.Mutex {
+	if deviceID == "" {
+		return &sync.Mutex{}
+	}
+	if v, ok := uc.subscribeActionLocks.Load(deviceID); ok {
+		return v.(*sync.Mutex)
+	}
+	m := &sync.Mutex{}
+	actual, _ := uc.subscribeActionLocks.LoadOrStore(deviceID, m)
+	return actual.(*sync.Mutex)
 }
 
 // Login authenticates a device using a double-hashed token.
@@ -794,7 +814,7 @@ func (uc *InstanceUsecase) PushMessages(ctx context.Context, messages interface{
 		// Log summary of message types received in this push batch
 		fmt.Printf("DEBUG: Push batch summary - Total messages: %d, Type breakdown: %v\n", len(protoMsgs), messageTypeCount)
 		if messageTypeCount["status-message"] == 0 && messageTypeCount["StatusMessage"] == 0 && messageTypeCount["status"] == 0 {
-			fmt.Printf("WARNING: No StatusMessage in push batch. Device must send StatusMessage (1-second heartbeat) to update health_status. Message types: %v\n", messageTypeCount)
+			fmt.Printf("WARNING: No heartbeat status message in push batch. Device must send one of status-message, StatusMessage, or status (1-second heartbeat) to update health_status. Message types: %v\n", messageTypeCount)
 		}
 		
 		return nil

--- a/device-management/internal/biz/instance.go
+++ b/device-management/internal/biz/instance.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -181,20 +180,6 @@ func (uc *InstanceUsecase) EnsureStatusSubscription(ctx context.Context, deviceI
 		return
 	}
 
-	mu := uc.subscribeActionMutex(deviceID)
-	mu.Lock()
-	defer mu.Unlock()
-
-	// Avoid spamming: if there's already a pending subscribe action, don't add another.
-	pending, err := uc.store.Actions().ListPending(ctx, tenantID, deviceID)
-	if err == nil {
-		for _, a := range pending {
-			if a != nil && a.Type == subscribeActionType {
-				return
-			}
-		}
-	}
-
 	payloadJSON, err := json.Marshal(map[string]any{
 		"resubscribed": true,
 	})
@@ -215,6 +200,10 @@ func (uc *InstanceUsecase) EnsureStatusSubscription(ctx context.Context, deviceI
 		ExpiresAt:  now.Add(time.Duration(subscribeActionDefaultTTLSeconds) * time.Second),
 	}
 	if err := uc.store.Actions().Save(ctx, tenantID, action); err != nil {
+		// Ignore "already exists" for idempotency across replicas (db-level uniqueness).
+		if err.Error() == "record already exists" {
+			return
+		}
 		// Non-fatal: health still works without summaries.
 		fmt.Printf("Warning: failed to queue subscribe action for device %s: %v\n", deviceID, err)
 	}
@@ -227,8 +216,6 @@ type InstanceUsecase struct {
 	protocolConverterRepo *data.ProtocolConverterRepo
 	dataModelRepo         *data.DataModelRepo
 	streamProcessorRepo   *data.StreamProcessorRepo
-
-	subscribeActionLocks sync.Map // map[deviceID]*sync.Mutex
 }
 
 // NewInstanceUsecase creates a new InstanceUsecase with the given storage and authentication backends.
@@ -242,17 +229,6 @@ func NewInstanceUsecase(store storage.Store, authUc *AuthUsecase, protocolConver
 	}
 }
 
-func (uc *InstanceUsecase) subscribeActionMutex(deviceID string) *sync.Mutex {
-	if deviceID == "" {
-		return &sync.Mutex{}
-	}
-	if v, ok := uc.subscribeActionLocks.Load(deviceID); ok {
-		return v.(*sync.Mutex)
-	}
-	m := &sync.Mutex{}
-	actual, _ := uc.subscribeActionLocks.LoadOrStore(deviceID, m)
-	return actual.(*sync.Mutex)
-}
 
 // Login authenticates a device using a double-hashed token.
 // CRITICAL: Used by /v2/instance/login endpoint

--- a/device-management/internal/biz/instance.go
+++ b/device-management/internal/biz/instance.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/klauspost/compress/zstd"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"gopkg.in/yaml.v3"
 
@@ -159,6 +160,60 @@ func (uc *InstanceUsecase) persistActionErrorMessageIfFailed(ctx context.Context
 	}
 }
 
+const (
+	// subscribeActionType is a taksa-edge-umh compatible message that registers a "subscriber" so the edge emits periodic status heartbeats.
+	// In the taksa-edge-umh fork, status heartbeats are only emitted while at least one subscriber exists.
+	subscribeActionType = "subscribe"
+	// subscribeActionDefaultTTLSeconds should be <= edge subscriber TTL to avoid stale subscribe actions piling up.
+	subscribeActionDefaultTTLSeconds int32 = 120
+)
+
+// EnsureStatusSubscription queues a lightweight "subscribe" action for the device (if not already pending).
+// This is used so that taksa-edge-umh will emit MessageType "status" heartbeats even when no UI is open.
+func (uc *InstanceUsecase) EnsureStatusSubscription(ctx context.Context, deviceID string) {
+	if deviceID == "" {
+		return
+	}
+	tenantID := middleware.GetTenantID(ctx)
+	if tenantID == "" {
+		return
+	}
+
+	// Avoid spamming: if there's already a pending subscribe action, don't add another.
+	pending, err := uc.store.Actions().ListPending(ctx, tenantID, deviceID)
+	if err == nil {
+		for _, a := range pending {
+			if a != nil && a.Type == subscribeActionType {
+				return
+			}
+		}
+	}
+
+	payloadJSON, err := json.Marshal(map[string]any{
+		"resubscribed": true,
+	})
+	if err != nil {
+		return
+	}
+
+	now := time.Now()
+	action := &models.Action{
+		Id:         generateUUID(),
+		DeviceId:   deviceID,
+		Type:       subscribeActionType,
+		Payload:    &anypb.Any{Value: payloadJSON},
+		MaxRetries: 0,
+		RetryCount: 0,
+		Status:     models.ActionStatusQueued,
+		CreatedAt:  now,
+		ExpiresAt:  now.Add(time.Duration(subscribeActionDefaultTTLSeconds) * time.Second),
+	}
+	if err := uc.store.Actions().Save(ctx, tenantID, action); err != nil {
+		// Non-fatal: health still works without summaries.
+		fmt.Printf("Warning: failed to queue subscribe action for device %s: %v\n", deviceID, err)
+	}
+}
+
 // InstanceUsecase handles device-facing operations: authentication, message polling, and status reporting.
 type InstanceUsecase struct {
 	store                 storage.Store
@@ -285,6 +340,9 @@ func (uc *InstanceUsecase) Login(ctx context.Context, tokenHash string) (*LoginR
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate JWT: %w", err)
 	}
+
+	// Queue a subscribe so the edge starts emitting status heartbeats.
+	uc.EnsureStatusSubscription(ctx, deviceID)
 
 	return &LoginResponse{
 		JwtToken:            jwtToken,
@@ -726,7 +784,8 @@ func (uc *InstanceUsecase) PushMessages(ctx context.Context, messages interface{
 			}
 
 			// TASK 2: Sync protocol converters and stream processors from StatusMessage
-			if msgType == "status-message" || msgType == "StatusMessage" {
+			// taksa-edge-umh sends MessageType "status" (not "status-message")
+			if msgType == "status-message" || msgType == "StatusMessage" || msgType == "status" {
 				_ = uc.syncProtocolConvertersFromStatusMessage(ctx, tenantID, deviceID, msg.Content)
 				_ = uc.syncStreamProcessorsFromStatusMessage(ctx, tenantID, deviceID, msg.Content)
 			}
@@ -734,7 +793,7 @@ func (uc *InstanceUsecase) PushMessages(ctx context.Context, messages interface{
 		
 		// Log summary of message types received in this push batch
 		fmt.Printf("DEBUG: Push batch summary - Total messages: %d, Type breakdown: %v\n", len(protoMsgs), messageTypeCount)
-		if messageTypeCount["status-message"] == 0 && messageTypeCount["StatusMessage"] == 0 {
+		if messageTypeCount["status-message"] == 0 && messageTypeCount["StatusMessage"] == 0 && messageTypeCount["status"] == 0 {
 			fmt.Printf("WARNING: No StatusMessage in push batch. Device must send StatusMessage (1-second heartbeat) to update health_status. Message types: %v\n", messageTypeCount)
 		}
 		

--- a/device-management/internal/service/devicemgmt.go
+++ b/device-management/internal/service/devicemgmt.go
@@ -327,6 +327,12 @@ func (s *DeviceMgmtService) GetDeviceHealth(ctx context.Context, req *v1.GetDevi
 		return nil, status.Error(codes.InvalidArgument, "device_id is required")
 	}
 
+	// Ensure the edge has a "subscriber" so it emits periodic status heartbeats (MessageType "status").
+	// This is best-effort; the health call still succeeds without summaries.
+	if s.instanceUc != nil {
+		s.instanceUc.EnsureStatusSubscription(ctx, req.DeviceId)
+	}
+
 	// Call business logic
 	resp, err := s.deviceUc.GetDeviceHealth(ctx, req.DeviceId)
 	if err != nil {
@@ -336,11 +342,16 @@ func (s *DeviceMgmtService) GetDeviceHealth(ctx context.Context, req *v1.GetDevi
 	// Map response
 	return &v1.DeviceHealthResponse{
 		DeviceId:        resp.DeviceId,
-		LastUpdated:     resp.LastUpdated,
+		DeviceStatus:    resp.DeviceStatus,
+		LastSeen:        resp.LastSeen,
 		Status:          resp.Status,
 		StatusB64:       resp.StatusB64,
 		DeviceTimestamp: resp.DeviceTimestamp,
 		ErrorMessage:    resp.ErrorMessage,
+		CoreHealth:      resp.CoreHealth,
+		AgentLatency:    resp.AgentLatency,
+		Resources:       resp.Resources,
+		Release:         resp.Release,
 	}, nil
 }
 

--- a/device-management/internal/service/devicemgmt.go
+++ b/device-management/internal/service/devicemgmt.go
@@ -328,9 +328,14 @@ func (s *DeviceMgmtService) GetDeviceHealth(ctx context.Context, req *v1.GetDevi
 	}
 
 	// Ensure the edge has a "subscriber" so it emits periodic status heartbeats (MessageType "status").
-	// This is best-effort; the health call still succeeds without summaries.
+	// This is best-effort; do not block the health call on subscription maintenance.
 	if s.instanceUc != nil {
-		s.instanceUc.EnsureStatusSubscription(ctx, req.DeviceId)
+		deviceID := req.DeviceId
+		go func() {
+			subscriptionCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+			defer cancel()
+			s.instanceUc.EnsureStatusSubscription(subscriptionCtx, deviceID)
+		}()
 	}
 
 	// Call business logic
@@ -344,8 +349,6 @@ func (s *DeviceMgmtService) GetDeviceHealth(ctx context.Context, req *v1.GetDevi
 		DeviceId:        resp.DeviceId,
 		DeviceStatus:    resp.DeviceStatus,
 		LastSeen:        resp.LastSeen,
-		Status:          resp.Status,
-		StatusB64:       resp.StatusB64,
 		DeviceTimestamp: resp.DeviceTimestamp,
 		ErrorMessage:    resp.ErrorMessage,
 		CoreHealth:      resp.CoreHealth,

--- a/device-management/internal/storage/postgres/action.go
+++ b/device-management/internal/storage/postgres/action.go
@@ -37,6 +37,11 @@ func (s *ActionStore) Save(ctx context.Context, tenantID string, action *models.
 		max_retries, retry_count, status, created_at, expires_at
 	) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 	`
+	// For subscribe actions we want DB-level idempotency across replicas: only one QUEUED subscribe per device.
+	// This relies on the partial unique index uq_actions_subscribe_queued.
+	if action.Type == "subscribe" && action.Status == models.ActionStatusQueued {
+		query += ` ON CONFLICT (tenant_id, device_id, action_type) WHERE status = 1 DO NOTHING`
+	}
 
 	_, err := s.db.ExecContext(ctx, query,
 		action.Id, tenantID, action.DeviceId, action.Type,

--- a/device-management/internal/storage/postgres/device.go
+++ b/device-management/internal/storage/postgres/device.go
@@ -12,6 +12,7 @@ import (
 	v1 "github.com/artpark-hub/taksa-platform/device-management/api/devicemgmt/v1"
 	"github.com/artpark-hub/taksa-platform/device-management/internal/middleware"
 	"github.com/artpark-hub/taksa-platform/device-management/internal/storage"
+	"github.com/artpark-hub/taksa-platform/device-management/internal/utils"
 )
 
 // DeviceStore implements storage.DeviceStore for PostgreSQL
@@ -489,39 +490,7 @@ func allowUnscopedDeviceUpdate(ctx context.Context, id string) bool {
 // - Subsequently toggles between ACTIVE/INACTIVE based on last_seen activity.
 // - SUSPENDED/DECOMMISSIONED are terminal admin states.
 func deriveEffectiveDeviceStatus(device *v1.Device) v1.DeviceStatus {
-	if device == nil {
-		return v1.DeviceStatus_DEVICE_STATUS_UNSPECIFIED
-	}
-
-	switch device.Status {
-	case v1.DeviceStatus_SUSPENDED, v1.DeviceStatus_DECOMMISSIONED:
-		return device.Status
-	case v1.DeviceStatus_PENDING:
-		// Registration state always shows as PENDING until login flips status to ACTIVE.
-		// Do NOT use last_seen to infer ACTIVE/INACTIVE while still administratively PENDING
-		// (older rows or DB defaults may have last_seen initialized).
-		return v1.DeviceStatus_PENDING
-	default:
-		// Derive only for statuses that represent "logged in at least once" state
-		// (ACTIVE/INACTIVE) or legacy/unspecified rows. Keep other admin statuses as-is.
-		if device.Status != v1.DeviceStatus_ACTIVE &&
-			device.Status != v1.DeviceStatus_INACTIVE &&
-			device.Status != v1.DeviceStatus_DEVICE_STATUS_UNSPECIFIED {
-			return device.Status
-		}
-	}
-
-	// If we have a heartbeat timestamp, use it as the primary activity signal.
-	if device.LastSeen != nil {
-		lastSeen := device.LastSeen.AsTime()
-		if time.Since(lastSeen) <= deviceActiveWindow {
-			return v1.DeviceStatus_ACTIVE
-		}
-		return v1.DeviceStatus_INACTIVE
-	}
-
-	// No last_seen, but has logged in at least once.
-	return v1.DeviceStatus_INACTIVE
+	return utils.DeriveEffectiveDeviceStatus(device, deviceActiveWindow)
 }
 
 func statusToInt(s v1.DeviceStatus) int32 {

--- a/device-management/internal/storage/postgres/message.go
+++ b/device-management/internal/storage/postgres/message.go
@@ -145,7 +145,7 @@ func (s *MessageStore) ListHistory(ctx context.Context, filters *storage.Message
 	// Count total
 	countQuery := "SELECT COUNT(*) FROM messages " + whereClause
 	var total int32
-	err := s.db.QueryRowContext(ctx, countQuery, args[:len(args)-1]...).Scan(&total)
+	err := s.db.QueryRowContext(ctx, countQuery, args...).Scan(&total)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to count messages: %w", err)
 	}

--- a/device-management/internal/utils/device_status.go
+++ b/device-management/internal/utils/device_status.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"time"
+
+	v1 "github.com/artpark-hub/taksa-platform/device-management/api/devicemgmt/v1"
+)
+
+// DeriveEffectiveDeviceStatus derives the "effective" device status used for list/health views.
+// Rules:
+// - PENDING stays PENDING until first login flips it
+// - SUSPENDED/DECOMMISSIONED are terminal admin statuses
+// - ACTIVE/INACTIVE are derived from last_seen within the provided activeWindow
+func DeriveEffectiveDeviceStatus(device *v1.Device, activeWindow time.Duration) v1.DeviceStatus {
+	if device == nil {
+		return v1.DeviceStatus_DEVICE_STATUS_UNSPECIFIED
+	}
+
+	switch device.Status {
+	case v1.DeviceStatus_SUSPENDED, v1.DeviceStatus_DECOMMISSIONED:
+		return device.Status
+	case v1.DeviceStatus_PENDING:
+		return v1.DeviceStatus_PENDING
+	default:
+		// Only derive for ACTIVE/INACTIVE/UNSPECIFIED. Preserve any other admin states.
+		if device.Status != v1.DeviceStatus_ACTIVE &&
+			device.Status != v1.DeviceStatus_INACTIVE &&
+			device.Status != v1.DeviceStatus_DEVICE_STATUS_UNSPECIFIED {
+			return device.Status
+		}
+	}
+
+	if device.LastSeen != nil {
+		if time.Since(device.LastSeen.AsTime()) <= activeWindow {
+			return v1.DeviceStatus_ACTIVE
+		}
+		return v1.DeviceStatus_INACTIVE
+	}
+	return v1.DeviceStatus_INACTIVE
+}
+

--- a/device-management/openapi.yaml
+++ b/device-management/openapi.yaml
@@ -1326,6 +1326,24 @@ components:
             description: |-
                 Device represents a managed edge device (runs UMH Core instance)
                  Contains full details including certificates. Use DeviceSummary for list/summary responses.
+        api.devicemgmt.v1.DeviceAgentLatencySummary:
+            type: object
+            properties:
+                avg_ms:
+                    type: number
+                    format: double
+                max_ms:
+                    type: number
+                    format: double
+                min_ms:
+                    type: number
+                    format: double
+                p95_ms:
+                    type: number
+                    format: double
+                p99_ms:
+                    type: number
+                    format: double
         api.devicemgmt.v1.DeviceConfigActionResponse:
             type: object
             properties:
@@ -1343,24 +1361,59 @@ components:
                     $ref: '#/components/schemas/api.umh_core.v2.GetConfigFileResponse'
                 setConfigResponse:
                     $ref: '#/components/schemas/api.umh_core.v2.SetConfigFileResponse'
+        api.devicemgmt.v1.DeviceCoreHealthSummary:
+            type: object
+            properties:
+                message:
+                    type: string
+                state:
+                    type: string
+                desired_state:
+                    type: string
+                category:
+                    type: string
+                    description: 'Category: "active" | "degraded" | "neutral"'
         api.devicemgmt.v1.DeviceHealthResponse:
             type: object
             properties:
                 deviceId:
                     type: string
-                lastUpdated:
+                last_seen:
                     type: string
+                    description: |-
+                        Last time the device communicated with device-management (Pull heartbeat).
+                         Note: this replaces the former last_updated field (same tag = 2).
                     format: date-time
                 status:
-                    $ref: '#/components/schemas/api.umh_core.v2.StatusMessage'
+                    allOf:
+                        - $ref: '#/components/schemas/api.umh_core.v2.StatusMessage'
+                    description: 'Deprecated: intentionally not populated by server to keep /health summary-only.'
                 statusB64:
                     type: string
+                    description: 'Deprecated: intentionally not populated by server to keep /health summary-only.'
                 deviceTimestamp:
                     type: string
                     format: date-time
                 errorMessage:
                     type: string
-            description: DeviceHealthResponse contains health metrics from latest Push API data
+                deviceStatus:
+                    type: integer
+                    description: Effective device status derived from last_seen (ACTIVE/INACTIVE), matching ListDevices.
+                    format: enum
+                core_health:
+                    allOf:
+                        - $ref: '#/components/schemas/api.devicemgmt.v1.DeviceCoreHealthSummary'
+                    description: Latest device-reported health summaries (when the device sends StatusMessage heartbeats)
+                agent_latency:
+                    $ref: '#/components/schemas/api.devicemgmt.v1.DeviceAgentLatencySummary'
+                resources:
+                    $ref: '#/components/schemas/api.devicemgmt.v1.DeviceResourcesSummary'
+                release:
+                    $ref: '#/components/schemas/api.devicemgmt.v1.DeviceReleaseSummary'
+            description: |-
+                DeviceHealthResponse contains health metrics from latest Push API data.
+                 This endpoint is intentionally summary-only: it avoids returning the full device StatusMessage payload
+                 (which may include large blobs like UNS bundles, or detailed per-component inventories).
         api.devicemgmt.v1.DeviceLocation:
             type: object
             properties:
@@ -1403,6 +1456,45 @@ components:
                 macAddress:
                     type: string
             description: DeviceMetadata contains hardware and software information
+        api.devicemgmt.v1.DeviceReleaseSummary:
+            type: object
+            properties:
+                version:
+                    type: string
+                channel:
+                    type: string
+        api.devicemgmt.v1.DeviceResourcesSummary:
+            type: object
+            properties:
+                cpu_total_usage_m_cpu:
+                    type: number
+                    description: CPU
+                    format: double
+                cpu_core_count:
+                    type: integer
+                    format: int32
+                cpu_cgroup_cores:
+                    type: number
+                    format: double
+                cpu_throttle_ratio:
+                    type: number
+                    format: double
+                cpu_is_throttled:
+                    type: boolean
+                memory_used_bytes:
+                    type: string
+                    description: Memory / Disk
+                memory_total_bytes:
+                    type: string
+                disk_used_bytes:
+                    type: string
+                disk_total_bytes:
+                    type: string
+                hwid:
+                    type: string
+                    description: Hardware / runtime info
+                architecture:
+                    type: string
         api.devicemgmt.v1.DeviceSummary:
             type: object
             properties:

--- a/device-management/openapi.yaml
+++ b/device-management/openapi.yaml
@@ -1378,19 +1378,12 @@ components:
             properties:
                 deviceId:
                     type: string
-                last_seen:
+                lastSeen:
                     type: string
                     description: |-
                         Last time the device communicated with device-management (Pull heartbeat).
                          Note: this replaces the former last_updated field (same tag = 2).
                     format: date-time
-                status:
-                    allOf:
-                        - $ref: '#/components/schemas/api.umh_core.v2.StatusMessage'
-                    description: 'Deprecated: intentionally not populated by server to keep /health summary-only.'
-                statusB64:
-                    type: string
-                    description: 'Deprecated: intentionally not populated by server to keep /health summary-only.'
                 deviceTimestamp:
                     type: string
                     format: date-time
@@ -1400,11 +1393,11 @@ components:
                     type: integer
                     description: Effective device status derived from last_seen (ACTIVE/INACTIVE), matching ListDevices.
                     format: enum
-                core_health:
+                coreHealth:
                     allOf:
                         - $ref: '#/components/schemas/api.devicemgmt.v1.DeviceCoreHealthSummary'
                     description: Latest device-reported health summaries (when the device sends StatusMessage heartbeats)
-                agent_latency:
+                agentLatency:
                     $ref: '#/components/schemas/api.devicemgmt.v1.DeviceAgentLatencySummary'
                 resources:
                     $ref: '#/components/schemas/api.devicemgmt.v1.DeviceResourcesSummary'
@@ -1826,38 +1819,6 @@ components:
                 location:
                     $ref: '#/components/schemas/api.devicemgmt.v1.DeviceLocation'
             description: UpdateDeviceRequest updates device information
-        api.umh_core.v2.Agent:
-            type: object
-            properties:
-                health:
-                    $ref: '#/components/schemas/api.umh_core.v2.Health'
-                latency:
-                    $ref: '#/components/schemas/api.umh_core.v2.Latency'
-                location:
-                    type: object
-                    additionalProperties:
-                        type: string
-            description: 'Agent: Device agent state and configuration'
-        api.umh_core.v2.CPU:
-            type: object
-            properties:
-                health:
-                    $ref: '#/components/schemas/api.umh_core.v2.Health'
-                totalUsageMCpu:
-                    type: number
-                    format: double
-                coreCount:
-                    type: integer
-                    format: int32
-                cgroupCores:
-                    type: number
-                    format: double
-                throttleRatio:
-                    type: number
-                    format: double
-                isThrottled:
-                    type: boolean
-            description: 'CPU: CPU metrics with cgroup limits'
         api.umh_core.v2.CdcfMeta:
             type: object
             properties:
@@ -1909,76 +1870,6 @@ components:
                 data:
                     type: string
             description: 'CommonDataFlowComponentRawYamlConfig: Raw YAML configuration fallback'
-        api.umh_core.v2.Connection:
-            type: object
-            properties:
-                uuid:
-                    type: string
-                name:
-                    type: string
-                health:
-                    $ref: '#/components/schemas/api.umh_core.v2.Health'
-                uri:
-                    type: string
-                lastLatencyMs:
-                    type: number
-                    format: double
-            description: 'Connection: External system connection state'
-        api.umh_core.v2.Container:
-            type: object
-            properties:
-                health:
-                    $ref: '#/components/schemas/api.umh_core.v2.Health'
-                cpu:
-                    $ref: '#/components/schemas/api.umh_core.v2.CPU'
-                disk:
-                    $ref: '#/components/schemas/api.umh_core.v2.Disk'
-                memory:
-                    $ref: '#/components/schemas/api.umh_core.v2.Memory'
-                hwid:
-                    type: string
-                architecture:
-                    type: string
-            description: 'Container: Hardware and resource information'
-        api.umh_core.v2.Core:
-            type: object
-            properties:
-                health:
-                    $ref: '#/components/schemas/api.umh_core.v2.Health'
-                agent:
-                    $ref: '#/components/schemas/api.umh_core.v2.Agent'
-                container:
-                    $ref: '#/components/schemas/api.umh_core.v2.Container'
-                release:
-                    $ref: '#/components/schemas/api.umh_core.v2.Release'
-                dfcs:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/api.umh_core.v2.Dfc'
-                redpanda:
-                    $ref: '#/components/schemas/api.umh_core.v2.Redpanda'
-                topicBrowser:
-                    $ref: '#/components/schemas/api.umh_core.v2.TopicBrowser'
-                dataModels:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/api.umh_core.v2.DataModel'
-                dataContracts:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/api.umh_core.v2.DataContract'
-            description: 'Core: Root system state container'
-        api.umh_core.v2.DataContract:
-            type: object
-            properties:
-                name:
-                    type: string
-                dataModel:
-                    $ref: '#/components/schemas/api.umh_core.v2.DataContractRef'
-                flows:
-                    type: integer
-                    format: int32
-            description: 'DataContract: Data contract definition'
         api.umh_core.v2.DataContractInfo:
             type: object
             properties:
@@ -1989,14 +1880,6 @@ components:
                 status:
                     type: string
             description: 'DataContractInfo: Data contract created by data model operations'
-        api.umh_core.v2.DataContractRef:
-            type: object
-            properties:
-                name:
-                    type: string
-                version:
-                    type: string
-            description: 'DataContractRef: Reference to a data model'
         api.umh_core.v2.DataFlowComponent:
             type: object
             properties:
@@ -2054,18 +1937,6 @@ components:
                 data:
                     type: string
             description: 'DataFlowComponentProcessor: Individual processor configuration'
-        api.umh_core.v2.DataModel:
-            type: object
-            properties:
-                name:
-                    type: string
-                description:
-                    type: string
-                latestVersion:
-                    type: string
-                hash:
-                    type: string
-            description: 'DataModel: Data model metadata'
         api.umh_core.v2.DataModelOperationResult:
             type: object
             properties:
@@ -2104,57 +1975,6 @@ components:
                 ignoreHealthCheck:
                     type: boolean
             description: 'DeployDataFlowComponentPayload: Deploy a data flow component'
-        api.umh_core.v2.Dfc:
-            type: object
-            properties:
-                uuid:
-                    type: string
-                name:
-                    type: string
-                dfcType:
-                    type: string
-                health:
-                    $ref: '#/components/schemas/api.umh_core.v2.Health'
-                metrics:
-                    $ref: '#/components/schemas/api.umh_core.v2.DfcMetrics'
-                connections:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/api.umh_core.v2.Connection'
-                bridge:
-                    $ref: '#/components/schemas/api.umh_core.v2.DfcBridgeInfo'
-                isInitialized:
-                    type: boolean
-                currentVersionUUID:
-                    type: string
-            description: 'Dfc: Data Flow Component state'
-        api.umh_core.v2.DfcBridgeInfo:
-            type: object
-            properties:
-                dataContract:
-                    type: string
-                inputType:
-                    type: string
-                outputType:
-                    type: string
-            description: 'DfcBridgeInfo: Bridge-specific metadata'
-        api.umh_core.v2.DfcMetrics:
-            type: object
-            properties:
-                avgInputThroughputPerMinuteInMsgSec:
-                    type: number
-                    format: double
-            description: 'DfcMetrics: Data Flow Component performance metrics'
-        api.umh_core.v2.Disk:
-            type: object
-            properties:
-                health:
-                    $ref: '#/components/schemas/api.umh_core.v2.Health'
-                dataPartitionUsedBytes:
-                    type: string
-                dataPartitionTotalBytes:
-                    type: string
-            description: 'Disk: Storage metrics'
         api.umh_core.v2.EditDataFlowComponentPayload:
             type: object
             properties:
@@ -2227,37 +2047,6 @@ components:
                         Component UUID - REQUIRED if type is: dfc, protocol-converter, stream-processor
                          For other types, this field is ignored
             description: 'GetMetricsPayload: Retrieve metrics from various services'
-        api.umh_core.v2.Health:
-            type: object
-            properties:
-                message:
-                    type: string
-                state:
-                    type: string
-                desiredState:
-                    type: string
-                category:
-                    type: string
-            description: 'Health: Health state with category'
-        api.umh_core.v2.Latency:
-            type: object
-            properties:
-                avgMs:
-                    type: number
-                    format: double
-                maxMs:
-                    type: number
-                    format: double
-                minMs:
-                    type: number
-                    format: double
-                p95Ms:
-                    type: number
-                    format: double
-                p99Ms:
-                    type: number
-                    format: double
-            description: 'Latency: Latency metrics with percentiles'
         api.umh_core.v2.LoginResponse:
             type: object
             properties:
@@ -2277,16 +2066,6 @@ components:
                     type: string
                     format: date-time
             description: "LoginResponse returns device information and authentication token\n Matches umh-core's InstanceLoginResponse (backend_api_structs/backend_api_struct.go:119-125)\n but includes jwtToken for device-management client convenience\n \n CRITICAL: Uses common.CompanyDetails and common.LicenseStatus for wire protocol compatibility\n These are the exact types that umh-core sends, ensuring 100% compatibility"
-        api.umh_core.v2.Memory:
-            type: object
-            properties:
-                health:
-                    $ref: '#/components/schemas/api.umh_core.v2.Health'
-                cGroupUsedBytes:
-                    type: string
-                cGroupTotalBytes:
-                    type: string
-            description: 'Memory: Memory metrics'
         api.umh_core.v2.ProtocolConverter:
             type: object
             properties:
@@ -2398,36 +2177,6 @@ components:
                     items:
                         $ref: '#/components/schemas/api.umh_core.v2.UMHMessage'
             description: PushRequest sends device status/telemetry to console
-        api.umh_core.v2.Redpanda:
-            type: object
-            properties:
-                health:
-                    $ref: '#/components/schemas/api.umh_core.v2.Health'
-                avgIncomingThroughputPerMinuteInBytesSec:
-                    type: number
-                    format: double
-                avgOutgoingThroughputPerMinuteInBytesSec:
-                    type: number
-                    format: double
-            description: 'Redpanda: Message broker state'
-        api.umh_core.v2.Release:
-            type: object
-            properties:
-                health:
-                    $ref: '#/components/schemas/api.umh_core.v2.Health'
-                version:
-                    type: string
-                channel:
-                    type: string
-                supportedFeatures:
-                    type: array
-                    items:
-                        type: string
-                versions:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/api.umh_core.v2.Version'
-            description: 'Release: Version and feature information'
         api.umh_core.v2.SetConfigFilePayload:
             type: object
             properties:
@@ -2451,17 +2200,6 @@ components:
                 SetConfigFileResponse: Response from SetConfigFile action
                  Matches umh-core's models.SetConfigFileResponse exactly (pkg/models/action_models.go:618-622)
                  Note: content field echoes back the entire file that was written (for confirmation/audit purposes)
-        api.umh_core.v2.StatusMessage:
-            type: object
-            properties:
-                core:
-                    $ref: '#/components/schemas/api.umh_core.v2.Core'
-                plugins:
-                    type: object
-                    additionalProperties:
-                        type: string
-                        format: bytes
-            description: 'StatusMessage: Complete system state sent by device (via Push API)'
         api.umh_core.v2.StreamProcessorModelRef:
             type: object
             properties:
@@ -2470,20 +2208,6 @@ components:
                 version:
                     type: string
             description: 'StreamProcessorModelRef: Reference to a data model'
-        api.umh_core.v2.TopicBrowser:
-            type: object
-            properties:
-                health:
-                    $ref: '#/components/schemas/api.umh_core.v2.Health'
-                unsBundles:
-                    type: object
-                    additionalProperties:
-                        type: string
-                        format: bytes
-                topicCount:
-                    type: integer
-                    format: int32
-            description: 'TopicBrowser: Topic catalog state'
         api.umh_core.v2.UMHMessage:
             type: object
             properties:
@@ -2500,14 +2224,6 @@ components:
                  MUST match umh-core's models.UMHMessage exactly (pkg/models/action_models.go:79-84)
                  Wire protocol - clean, simple, compatible with umh-core
                  Internal correlation tracking is handled separately in device-management
-        api.umh_core.v2.Version:
-            type: object
-            properties:
-                name:
-                    type: string
-                version:
-                    type: string
-            description: 'Version: Component version information'
 tags:
     - name: DeviceMgmtService
       description: |-


### PR DESCRIPTION
… summaries

- Extend health response with summary-only telemetry: core health, agent latency, resources, release
- Make health status consistent with ListDevices by deriving ACTIVE/INACTIVE from last_seen
- Add DM-driven edge subscription: queue "subscribe" on device login and each health call (enables taksa-edge-umh MessageType "status" heartbeats)
- Accept edge heartbeat variants in sync/health: "status", "status-message", "StatusMessage"
- Fix Postgres message history count query (ListHistory COUNT args)