### PR TITLE
fix(device-management): correct HTTP health check for Docker

### DIFF
--- a/device-management/Dockerfile
+++ b/device-management/Dockerfile
@@ -16,8 +16,9 @@ COPY --chown=taksa:taksa configs ./configs
 
 USER taksa
 
+# Use GET (-O /dev/null), not wget --spider: spider sends HEAD and Kratos only registers GET for /health → 404.
 HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:8000/ || exit 1
+    CMD wget --no-verbose --tries=1 -O /dev/null http://localhost:8000/health || exit 1
 
 EXPOSE 8000 9000
 

--- a/device-management/docker-compose.yml
+++ b/device-management/docker-compose.yml
@@ -26,7 +26,8 @@ services:
       - taksa-network
     restart: unless-stopped
     healthcheck:
-      test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8000/" ]
+      # GET required: --spider uses HEAD; /health has no HEAD route → 404.
+      test: [ "CMD", "wget", "--no-verbose", "--tries=1", "-O", "/dev/null", "http://localhost:8000/health" ]
       interval: 10s
       timeout: 3s
       retries: 3


### PR DESCRIPTION
Probe /health instead of / 
with GET (wget -O /dev/null) instead of --spider HEAD, which returned 404
align compose and Dockerfile.