### PR TITLE
fix(device-management): retry Postgres ping on startup

### DIFF
--- a/device-management/internal/data/data.go
+++ b/device-management/internal/data/data.go
@@ -32,12 +32,6 @@ func NewData(c *conf.Data, logger log.Logger) (*Data, func(), error) {
 		return nil, nil, fmt.Errorf("failed to create database: %w", err)
 	}
 
-	// Test connection
-	if err := db.Ping(); err != nil {
-		_ = db.Close()
-		return nil, nil, fmt.Errorf("failed to ping database: %w", err)
-	}
-
 	// PostgreSQL only: schema is managed via migrations
 	if c.Database.Driver != "postgres" {
 		_ = db.Close()

--- a/device-management/internal/db/postgres.go
+++ b/device-management/internal/db/postgres.go
@@ -39,10 +39,21 @@ func NewPostgresDatabase(config PostgresConfig) (*sql.DB, error) {
 		db.SetConnMaxIdleTime(time.Duration(config.ConnMaxIdleTime) * time.Second)
 	}
 
-	// Test connection
-	if err := db.Ping(); err != nil {
-		return nil, fmt.Errorf("failed to ping PostgreSQL database: %w", err)
+	// Wait for PostgreSQL to accept connections (e.g. container startup / restarts).
+	const (
+		maxAttempts = 30
+		interval    = time.Second
+	)
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		lastErr = db.Ping()
+		if lastErr == nil {
+			return db, nil
+		}
+		if attempt < maxAttempts {
+			time.Sleep(interval)
+		}
 	}
-
-	return db, nil
+	_ = db.Close()
+	return nil, fmt.Errorf("failed to ping PostgreSQL database after %d attempts: %w", maxAttempts, lastErr)
 }

--- a/device-management/internal/storage/postgres/store.go
+++ b/device-management/internal/storage/postgres/store.go
@@ -27,11 +27,6 @@ func NewStore(db *sql.DB) (storage.Store, error) {
 		return nil, fmt.Errorf("database connection is nil")
 	}
 
-	// Test the connection
-	if err := db.Ping(); err != nil {
-		return nil, fmt.Errorf("failed to ping PostgreSQL database: %w", err)
-	}
-
 	return &Store{
 		db:                    db,
 		devices:               &DeviceStore{db: db},


### PR DESCRIPTION
- Retry Ping() with backoff during pool init;
- remove duplicate pings in data and storage layers.

Refs artpark-hub/taksa#24