### PR TITLE
Auto add NATS output config to DCDs

### DIFF
--- a/device-management/.env.example
+++ b/device-management/.env.example
@@ -25,3 +25,6 @@ TAKSA_DM_UMH_CORE_DOCKER_IMAGE=management.umh.app/oci/united-manufacturing-hub/u
 # Edge status auto re-subscribe on pull when catalog/status is stale (default true). Set false for heavy DCD fleets.
 # TAKSA_DM_AUTO_RESUBSCRIBE_STATUS_MESSAGES=false
 
+# NATS cluster URLs (comma-separated) for auto-deployed UNS→NATS mirror on DCD login. Leave empty to disable.
+# Example: nats://user:pass@nats.example.com:4222
+TAKSA_DM_NATS_MIRROR_URLS=

--- a/device-management/cmd/device-management/main.go
+++ b/device-management/cmd/device-management/main.go
@@ -82,7 +82,10 @@ func newZapLogger(logLevel, logFile string) (*zap.Logger, error) {
 	return cfg.Build()
 }
 
-func newApp(logger log.Logger, gs *grpc.Server, hs *http.Server) *kratos.App {
+func newApp(logger log.Logger, gs *grpc.Server, hs *http.Server, instanceUc *biz.InstanceUsecase) *kratos.App {
+	if instanceUc != nil {
+		instanceUc.StartNATSMirrorFleetReconcile()
+	}
 	return kratos.New(
 		kratos.ID(id),
 		kratos.Name(Name),
@@ -141,6 +144,9 @@ func main() {
 	}
 	if dockerImage := os.Getenv("TAKSA_DM_UMH_CORE_DOCKER_IMAGE"); dockerImage != "" {
 		bc.Deployment.UmhCoreDockerImage = dockerImage
+	}
+	if natsURLs := os.Getenv("TAKSA_DM_NATS_MIRROR_URLS"); natsURLs != "" {
+		bc.Deployment.NatsMirrorUrls = natsURLs
 	}
 	if jwtSecret := os.Getenv("TAKSA_DM_JWT_SECRET"); jwtSecret != "" {
 		bc.Server.JwtSecret = jwtSecret

--- a/device-management/cmd/device-management/main.go
+++ b/device-management/cmd/device-management/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -83,20 +84,27 @@ func newZapLogger(logLevel, logFile string) (*zap.Logger, error) {
 }
 
 func newApp(logger log.Logger, gs *grpc.Server, hs *http.Server, instanceUc *biz.InstanceUsecase) *kratos.App {
-	if instanceUc != nil {
-		instanceUc.StartNATSMirrorFleetReconcile()
-	}
-	return kratos.New(
+	opts := []kratos.Option{
 		kratos.ID(id),
 		kratos.Name(Name),
 		kratos.Version(Version),
 		kratos.Metadata(map[string]string{}),
 		kratos.Logger(logger),
-		kratos.Server(
-			gs,
-			hs,
-		),
-	)
+		kratos.Server(gs, hs),
+	}
+	if instanceUc != nil {
+		opts = append(opts,
+			kratos.BeforeStart(func(ctx context.Context) error {
+				instanceUc.StartNATSMirrorFleetReconcile(ctx)
+				return nil
+			}),
+			kratos.AfterStop(func(ctx context.Context) error {
+				instanceUc.StopNATSMirrorFleetReconcile()
+				return nil
+			}),
+		)
+	}
+	return kratos.New(opts...)
 }
 
 func main() {

--- a/device-management/configs/config.yaml
+++ b/device-management/configs/config.yaml
@@ -19,6 +19,8 @@ data:
 deployment:
   base_url: http://localhost:8000
   umh_core_docker_image: management.umh.app/oci/united-manufacturing-hub/umh-core:v0.43.17
+  # Comma-separated NATS URLs for the UNS→NATS mirror data flow (auto-queued on DCD login). Leave empty to disable.
+  nats_mirror_urls: ""
 # Edge status subscribe keepalive (topic catalog + health via push).
 # Set auto_resubscribe_status_messages: false for large fleets; use EnsureDeviceStatusSubscription per device.
 device_status_subscription:

--- a/device-management/db/migrations/002_nats_mirror_device.down.sql
+++ b/device-management/db/migrations/002_nats_mirror_device.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE devices DROP COLUMN IF EXISTS nats_mirror_deployed_at;

--- a/device-management/db/migrations/002_nats_mirror_device.up.sql
+++ b/device-management/db/migrations/002_nats_mirror_device.up.sql
@@ -1,0 +1,6 @@
+-- Persistent NATS mirror state per DCD (survives actions table cleanup).
+ALTER TABLE devices
+  ADD COLUMN IF NOT EXISTS nats_mirror_deployed_at TIMESTAMP WITH TIME ZONE;
+
+COMMENT ON COLUMN devices.nats_mirror_deployed_at IS
+  'Set when UNS-to-NATS-mirror deploy-data-flow-component succeeded on the edge; NULL = not yet deployed.';

--- a/device-management/db/migrations/003_nats_mirror_config_fingerprint.down.sql
+++ b/device-management/db/migrations/003_nats_mirror_config_fingerprint.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE devices DROP COLUMN IF EXISTS nats_mirror_config_fingerprint;

--- a/device-management/db/migrations/003_nats_mirror_config_fingerprint.up.sql
+++ b/device-management/db/migrations/003_nats_mirror_config_fingerprint.up.sql
@@ -1,0 +1,6 @@
+-- Track which NATS mirror URL set was last applied so config changes trigger edit-data-flow-component.
+ALTER TABLE devices
+  ADD COLUMN IF NOT EXISTS nats_mirror_config_fingerprint TEXT;
+
+COMMENT ON COLUMN devices.nats_mirror_config_fingerprint IS
+  'SHA-256 hex of sorted deployment NATS URLs last applied to UNS-to-NATS-mirror on this device';

--- a/device-management/db/migrations/README.md
+++ b/device-management/db/migrations/README.md
@@ -27,3 +27,5 @@ Populate topic rows via a real device status push (preferred) or the Bruno south
 | File | Description |
 |------|-------------|
 | `001_device_topics.up.sql` | `device_topics`, `device_topic_catalog`, indexes |
+| `002_nats_mirror_device.up.sql` | `devices.nats_mirror_deployed_at` (persistent UNS→NATS mirror state) |
+| `003_nats_mirror_config_fingerprint.up.sql` | `devices.nats_mirror_config_fingerprint` (detect NATS URL config changes) |

--- a/device-management/db/schema.postgres.sql
+++ b/device-management/db/schema.postgres.sql
@@ -39,6 +39,10 @@ CREATE TABLE IF NOT EXISTS devices (
   last_seen TIMESTAMP WITH TIME ZONE,
   last_login_at TIMESTAMP WITH TIME ZONE,
   auth_token_expires_at TIMESTAMP WITH TIME ZONE,
+
+  -- UNS→NATS mirror (deploy-data-flow-component UNS-to-NATS-mirror); survives actions cleanup
+  nats_mirror_deployed_at TIMESTAMP WITH TIME ZONE,
+  nats_mirror_config_fingerprint TEXT,
   
   UNIQUE(tenant_id, name),  -- Device names unique per tenant
   UNIQUE(uuid)

--- a/device-management/docker-compose.yml
+++ b/device-management/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - TAKSA_DM_DATABASE_DRIVER=${TAKSA_DM_DATABASE_DRIVER:-postgres}
       - TAKSA_DM_BASE_URL=${TAKSA_DM_BASE_URL:-http://$TAKSA_DOMAIN:$TAKSA_DM_HTTP_PORT}
       - TAKSA_DM_UMH_CORE_DOCKER_IMAGE=${TAKSA_DM_UMH_CORE_DOCKER_IMAGE:-management.umh.app/oci/united-manufacturing-hub/umh-core:v0.43.17}
+      - TAKSA_DM_NATS_MIRROR_URLS=${TAKSA_DM_NATS_MIRROR_URLS:-}
       - TAKSA_DM_JWT_SECRET
     volumes:
       - ${TAKSA_DM_DATA_DIR:-./data}:/data

--- a/device-management/docs/UNS_TO_NATS_MIRROR.md
+++ b/device-management/docs/UNS_TO_NATS_MIRROR.md
@@ -1,0 +1,283 @@
+# UNS → NATS mirror (per DCD)
+
+Device Management (DM) can automatically deploy and maintain a single **data flow component** on each edge DCD (umh-core instance) that mirrors **all** Unified Namespace (UNS) traffic to a platform NATS cluster. The mirror is **not** configured per tag or bridge: one `UNS-to-NATS-mirror` component subscribes to every UNS topic and publishes to NATS with a tenant- and device-scoped subject layout.
+
+This document covers **design**, **implementation**, and **operations**.
+
+---
+
+## Goals
+
+- Forward **all** UNS data from a DCD to NATS without creating a `dataFlow` entry per bridge or tag.
+- Use a stable NATS subject prefix: `{tenant_id}.{device_id}.uns.v1.<rest>`, rewriting only the **leading** `umh.v1` segment (not every occurrence in the path).
+- **Idempotent** lifecycle: first login deploys once; later logins and DM restarts update NATS URLs when platform config changes.
+- **Persistent** server-side state that survives cleanup of completed rows in the `actions` table.
+
+---
+
+## Non-goals (current behavior)
+
+- No public DM RPC to “force redeploy all” (fleet reconcile on startup covers config changes).
+- No read-back of the DFC config from the edge to verify what NATS URLs are actually running (DM trusts successful action replies).
+- Disabling mirror by clearing URLs does **not** undeploy the edge component (see [Disabling the feature](#disabling-the-feature)).
+- `tenant_id` / `device_id` in subjects are the **DM device / tenant** identifiers, not PLC or protocol-converter IDs.
+
+---
+
+## High-level architecture
+
+```mermaid
+flowchart TB
+  subgraph platform["Platform"]
+    ENV["config.yaml / TAKSA_DM_NATS_MIRROR_URLS"]
+    DM["Device Management"]
+    DB[("PostgreSQL devices row")]
+    ACT[("actions queue")]
+  end
+
+  subgraph edge["Edge DCD / umh-core"]
+    DFC["Data flow component\nUNS-to-NATS-mirror"]
+    UNS["UNS bus"]
+    NATS_OUT["NATS publisher"]
+  end
+
+  ENV --> DM
+  DM --> DB
+  DM --> ACT
+  ACT -->|"deploy / edit via instance pull"| DFC
+  UNS --> DFC --> NATS_OUT
+  NATS_OUT --> NATS_CLUSTER["Platform NATS"]
+```
+
+**Summary:** DM builds a Benthos-style custom DFC payload, queues `deploy-data-flow-component` or `edit-data-flow-component`, the DCD pulls the action, umh-core applies it, and DM records success on the `devices` row (timestamp + config fingerprint).
+
+---
+
+## Edge data flow design
+
+### Component identity
+
+| Field | Value |
+|-------|--------|
+| Name | `UNS-to-NATS-mirror` |
+| Meta type | `custom` |
+| State | `active` |
+| UUID | Deterministic: `uuid.NewSHA1(uuid.NameSpaceDNS, []byte("UNS-to-NATS-mirror"))` (same as umh-core `GenerateUUIDFromName`) |
+
+### Input (UNS)
+
+- `umh_topic`: `".*"` — all UNS topics on that DCD.
+- `consumer_group`: `dm_uns_nats_mirror_<device_id>` (hyphens stripped from device ID) — one consumer group per device.
+
+### Output (NATS)
+
+- `urls`: from platform config (comma-separated list).
+- `subject`: Bloblang expression:
+
+  ```
+  {tenant_id}.{device_id}.${! meta("umh_topic").re_replace("^umh\\.v1", "uns.v1") }
+  ```
+
+  Example: UNS topic `umh.v1.plant.line1.temperature` → NATS subject  
+  `{tenant}.{device}.uns.v1.plant.line1.temperature`.
+
+- `max_reconnects`: `-1`
+
+### Pipeline
+
+Minimal identity mapping (`root = this`) to satisfy umh-core validation.
+
+New bridges and tags on the DCD are picked up automatically because the mirror reads from UNS, not from per-resource `dataFlow` definitions.
+
+---
+
+## Platform configuration
+
+| Source | Key | Notes |
+|--------|-----|--------|
+| `configs/config.yaml` | `deployment.nats_mirror_urls` | Comma-separated NATS URLs, e.g. `nats://nats1:4222,nats://nats2:4222` |
+| Environment | `TAKSA_DM_NATS_MIRROR_URLS` | Overrides YAML when **non-empty** (`cmd/device-management/main.go`) |
+| Proto | `conf.Deployment.nats_mirror_urls` | `internal/conf/conf.proto` |
+
+**Empty URLs** → mirror logic is a no-op (no deploy, no edit, no fleet reconcile).
+
+---
+
+## Server-side persistence (not on the DCD)
+
+DM stores bookkeeping on each **device row** in PostgreSQL. The DCD only stores the operational DFC (including real NATS URLs inside umh-core config).
+
+| Column | Meaning |
+|--------|---------|
+| `nats_mirror_deployed_at` | Set when a deploy or edit action **succeeded** at least once; `NULL` = never successfully applied |
+| `nats_mirror_config_fingerprint` | SHA-256 hex of the **sorted, comma-joined** URL list DM last recorded as applied |
+
+The fingerprint is **not** sent to the edge. It lets DM detect “platform config changed since we last pushed to this device” without reading DFC state back from umh-core.
+
+Migrations:
+
+| Migration | Adds |
+|-----------|------|
+| `002_nats_mirror_device.up.sql` | `nats_mirror_deployed_at` |
+| `003_nats_mirror_config_fingerprint.up.sql` | `nats_mirror_config_fingerprint` |
+
+See `db/migrations/README.md` for the full list.
+
+---
+
+## Control flow
+
+### When mirror is ensured
+
+1. **Device login** — `InstanceUsecase.Login` calls `EnsureUNSToNATSMirror` after `EnsureStatusSubscription` (`internal/biz/instance.go`).
+2. **DM startup** — `newApp` (wired from `cmd/device-management/main.go`) calls `StartNATSMirrorFleetReconcile()`, which runs `ReconcileNATSMirrorFleet` once ~3s after start for all devices with a stale or missing fingerprint.
+
+### Decision logic (`ensureNATSMirrorForDevice`)
+
+```mermaid
+flowchart TD
+  A["Parse deployment.nats_mirror_urls"] --> B{URLs empty?}
+  B -->|yes| Z["Stop"]
+  B -->|no| C["Compute current fingerprint"]
+  C --> D{nats_mirror_deployed_at set?}
+  D -->|no| E{Inflight deploy/edit?}
+  D -->|yes| F{stored fingerprint == current?}
+  F -->|yes| Z
+  F -->|no| E
+  E -->|yes| Z
+  E -->|no| G{Ever deployed?}
+  G -->|no| H["Queue deploy-data-flow-component"]
+  G -->|yes| I["Queue edit-data-flow-component"]
+```
+
+**Inflight** = row in `actions` for this tenant/device with type `deploy-data-flow-component` or `edit-data-flow-component`, payload containing `UNS-to-NATS-mirror`, status queued or delivered (`internal/storage/postgres/action.go`).
+
+### Success handling
+
+When the instance service correlates a **successful** action reply (`correlateResponseByTraceId` / `correlateResponseByActionUUID`), `RecordNATSMirrorDeploySuccess` runs for deploy or edit actions and calls `SetNATSMirrorApplied` with the **current** deployment fingerprint (`internal/biz/nats_mirror.go`).
+
+Failed actions do not update the device row; a later login or reconcile can retry (subject to inflight checks).
+
+---
+
+## umh-core action contract
+
+| Phase | Action type | Payload shape |
+|-------|-------------|----------------|
+| First deploy | `deploy-data-flow-component` | `name`, `meta`, `state`, `payload.customDataFlowComponent` |
+| URL / config update | `edit-data-flow-component` | Same + top-level `uuid` (deterministic component UUID) |
+
+Action types use **kebab-case** to match umh-core models (not snake_case).
+
+Queued payload is wrapped in `google.protobuf.Any` with type URL `type.googleapis.com/taksa.edge.NATSMirrorDeployPayload`; umh-core consumes the raw JSON bytes.
+
+Payload construction: `internal/biz/nats_mirror.go` (`buildNATSMirrorDeployActionPayload`, `buildNATSMirrorEditActionPayload`).
+
+Unit tests: `internal/biz/nats_mirror_test.go`.
+
+---
+
+## Usage
+
+### Enable mirror for new devices
+
+1. Set NATS URLs in `.env` or `configs/config.yaml`:
+
+   ```bash
+   TAKSA_DM_NATS_MIRROR_URLS=nats://nats.platform.example:4222
+   ```
+
+2. Apply DB migrations `002` and `003` on the DM database.
+
+3. Start or restart device-management.
+
+4. When a DCD **logs in**, DM queues `deploy-data-flow-component` for `UNS-to-NATS-mirror` if not already deployed and no inflight action exists.
+
+5. After the edge reports success, verify NATS subjects under `{tenant_id}.{device_id}.uns.v1.*`.
+
+### Change NATS URLs (existing fleet)
+
+1. Update `TAKSA_DM_NATS_MIRROR_URLS` (or `deployment.nats_mirror_urls`).
+
+2. Restart DM.
+
+3. **Fleet reconcile** (~3s after startup) queues `edit-data-flow-component` for every device where:
+   - `nats_mirror_deployed_at IS NOT NULL`, and
+   - `nats_mirror_config_fingerprint` is `NULL` or differs from the new hash.
+
+4. Online devices pick up actions on pull; offline devices update on **next login** (same `ensureNATSMirrorForDevice` logic).
+
+5. After each successful edit, DM updates `nats_mirror_config_fingerprint` on that device row.
+
+Devices deployed **before** migration `003` have `NULL` fingerprint and are treated as needing one update after the first restart with new code.
+
+### Disabling the feature
+
+Setting URLs to empty stops **new** deploys and edits. It does **not** remove `UNS-to-NATS-mirror` from devices that already have it. To tear down on the edge, use umh-core / DM delete-data-flow-component flows separately (not automated by this feature today).
+
+**Note:** `TAKSA_DM_NATS_MIRROR_URLS` only overrides when non-empty; to clear URLs when YAML still has values, remove or empty the YAML entry as well.
+
+---
+
+## Operations checklist
+
+| Step | Action |
+|------|--------|
+| Schema | Run `002_nats_mirror_device.up.sql` and `003_nats_mirror_config_fingerprint.up.sql` |
+| Config | Set comma-separated NATS URLs |
+| Deploy DM | Restart after URL change |
+| Verify one device | Login DCD → check `actions` completes → confirm NATS traffic on expected subjects |
+| Verify fleet | Query devices with stale fingerprint (see below) |
+
+### Useful SQL
+
+```sql
+-- Devices that still need a config push after URL change
+SELECT id, tenant_id, nats_mirror_deployed_at, nats_mirror_config_fingerprint
+FROM devices
+WHERE nats_mirror_deployed_at IS NOT NULL
+  AND (nats_mirror_config_fingerprint IS NULL
+       OR nats_mirror_config_fingerprint <> '<current_sha256_hex>');
+
+-- Mirror never successfully applied
+SELECT id, tenant_id FROM devices WHERE nats_mirror_deployed_at IS NULL;
+```
+
+Compute `<current_sha256_hex>` the same way as DM: sort URLs, join with `,`, SHA-256, hex-encode (`NATSMirrorConfigFingerprint` in `internal/biz/nats_mirror.go`).
+
+### Inflight / stuck actions
+
+Check `actions` for the device with `action_type` in (`deploy-data-flow-component`, `edit-data-flow-component`) and payload containing `UNS-to-NATS-mirror`. Status `1`/`2` block duplicate queueing until the action completes or is cleaned up.
+
+---
+
+## Implementation index
+
+| Area | Location |
+|------|----------|
+| Core logic | `internal/biz/nats_mirror.go` |
+| Login hook | `internal/biz/instance.go` (`EnsureUNSToNATSMirror`) |
+| Action success | `internal/biz/instance.go` (`RecordNATSMirrorDeploySuccess`) |
+| Device store API | `internal/storage/device.go` |
+| Postgres | `internal/storage/postgres/device.go`, `internal/storage/postgres/action.go` |
+| Deployment proto | `internal/conf/conf.proto` |
+| Startup reconcile | `cmd/device-management/main.go` (`newApp` → `StartNATSMirrorFleetReconcile`) |
+| Tests | `internal/biz/nats_mirror_test.go` |
+| DDL | `db/schema.postgres.sql` (`devices` columns) |
+
+---
+
+## Consumer mental model
+
+1. **Platform config** defines which NATS cluster all mirrored DCDs should use.
+2. **Per-device DB columns** record what DM last successfully pushed (timestamp + URL-set fingerprint).
+3. **The DCD** holds the live DFC; DM updates it via the standard action queue, not a separate edge API.
+4. **Config changes** propagate via startup fleet reconcile and per-login ensure, using **edit** when the component already exists.
+5. **Subject layout** is fixed per tenant/device; only NATS `urls` (and the same subject template) change when you rotate brokers.
+
+---
+
+## Related documentation
+
+- Topic catalog (separate feature, also driven by status): `docs/TOPIC_BROWSER.md`
+- Action types in API surface: `api/devicemgmt/v1/devicemgmt.proto` (data flow component deploy/edit)

--- a/device-management/docs/UNS_TO_NATS_MIRROR.md
+++ b/device-management/docs/UNS_TO_NATS_MIRROR.md
@@ -130,7 +130,7 @@ See `db/migrations/README.md` for the full list.
 ### When mirror is ensured
 
 1. **Device login** — `InstanceUsecase.Login` calls `EnsureUNSToNATSMirror` after `EnsureStatusSubscription` (`internal/biz/instance.go`).
-2. **DM startup** — `newApp` (wired from `cmd/device-management/main.go`) calls `StartNATSMirrorFleetReconcile()`, which runs `ReconcileNATSMirrorFleet` once ~3s after start for all devices with a stale or missing fingerprint.
+2. **DM startup** — Kratos `BeforeStart` calls `StartNATSMirrorFleetReconcile(ctx)`, which runs `ReconcileNATSMirrorFleet` once ~3s later (cancellable via `AfterStop` on shutdown).
 
 ### Decision logic (`ensureNATSMirrorForDevice`)
 
@@ -150,7 +150,7 @@ flowchart TD
   G -->|yes| I["Queue edit-data-flow-component"]
 ```
 
-**Inflight** = row in `actions` for this tenant/device with type `deploy-data-flow-component` or `edit-data-flow-component`, payload containing `UNS-to-NATS-mirror`, status queued or delivered (`internal/storage/postgres/action.go`).
+**Inflight** = row in `actions` for this tenant/device with mirror payload and status `QUEUED`, `DELIVERED`, or `PROCESSING`. `NATSMirrorDeployInflight` checks deploy only; `NATSMirrorActionInflight` checks deploy or edit (`internal/storage/postgres/action.go`).
 
 ### Success handling
 

--- a/device-management/docs/UNS_TO_NATS_MIRROR.md
+++ b/device-management/docs/UNS_TO_NATS_MIRROR.md
@@ -156,7 +156,11 @@ flowchart TD
 
 When the instance service correlates a **successful** action reply (`correlateResponseByTraceId` / `correlateResponseByActionUUID`), `RecordNATSMirrorDeploySuccess` runs for deploy or edit actions and calls `SetNATSMirrorApplied` with the **current** deployment fingerprint (`internal/biz/nats_mirror.go`).
 
-Failed actions do not update the device row; a later login or reconcile can retry (subject to inflight checks).
+Failed actions do not update the device row, except:
+
+- **Edit failed with “not found”** (DFC removed on the edge while DM still has `nats_mirror_deployed_at`): `HandleNATSMirrorActionFailure` clears `nats_mirror_deployed_at` and `nats_mirror_config_fingerprint`, then queues **`deploy-data-flow-component`** immediately (same push correlation path as success).
+
+Other edit failures still require manual intervention or a later login/reconcile.
 
 ---
 
@@ -201,9 +205,9 @@ Unit tests: `internal/biz/nats_mirror_test.go`.
 
 2. Restart DM.
 
-3. **Fleet reconcile** (~3s after startup) queues `edit-data-flow-component` for every device where:
-   - `nats_mirror_deployed_at IS NOT NULL`, and
-   - `nats_mirror_config_fingerprint` is `NULL` or differs from the new hash.
+3. **Fleet reconcile** (~3s after startup) queues deploy or edit for every device where:
+   - `nats_mirror_deployed_at IS NULL` (never successfully applied), or
+   - `nats_mirror_config_fingerprint` is `NULL` or differs from the current hash.
 
 4. Online devices pick up actions on pull; offline devices update on **next login** (same `ensureNATSMirrorForDevice` logic).
 

--- a/device-management/internal/biz/instance.go
+++ b/device-management/internal/biz/instance.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -202,6 +203,9 @@ type InstanceUsecase struct {
 	statusSub             StatusSubscriptionSettings
 	deployment            *conf.Deployment
 	actionUc              *ActionUsecase
+
+	natsMirrorReconcileCancel context.CancelFunc
+	natsMirrorReconcileWG     sync.WaitGroup
 }
 
 // NewInstanceUsecase creates a new InstanceUsecase with the given storage and authentication backends.

--- a/device-management/internal/biz/instance.go
+++ b/device-management/internal/biz/instance.go
@@ -18,6 +18,7 @@ import (
 
 	v1 "github.com/artpark-hub/taksa-platform/device-management/api/devicemgmt/v1"
 	v2 "github.com/artpark-hub/taksa-platform/device-management/api/umh-core/v2"
+	"github.com/artpark-hub/taksa-platform/device-management/internal/conf"
 	"github.com/artpark-hub/taksa-platform/device-management/internal/data"
 	"github.com/artpark-hub/taksa-platform/device-management/internal/middleware"
 	"github.com/artpark-hub/taksa-platform/device-management/internal/models"
@@ -199,6 +200,8 @@ type InstanceUsecase struct {
 	streamProcessorRepo   *data.StreamProcessorRepo
 	deviceTopicRepo       *data.DeviceTopicRepo
 	statusSub             StatusSubscriptionSettings
+	deployment            *conf.Deployment
+	actionUc              *ActionUsecase
 }
 
 // NewInstanceUsecase creates a new InstanceUsecase with the given storage and authentication backends.
@@ -210,6 +213,8 @@ func NewInstanceUsecase(
 	streamProcessorRepo *data.StreamProcessorRepo,
 	deviceTopicRepo *data.DeviceTopicRepo,
 	statusSub StatusSubscriptionSettings,
+	deployment *conf.Deployment,
+	actionUc *ActionUsecase,
 ) *InstanceUsecase {
 	return &InstanceUsecase{
 		store:                 store,
@@ -219,6 +224,8 @@ func NewInstanceUsecase(
 		streamProcessorRepo:   streamProcessorRepo,
 		deviceTopicRepo:       deviceTopicRepo,
 		statusSub:             statusSub,
+		deployment:            deployment,
+		actionUc:              actionUc,
 	}
 }
 
@@ -332,6 +339,7 @@ func (uc *InstanceUsecase) Login(ctx context.Context, tokenHash string) (*LoginR
 
 	// Queue a subscribe so the edge starts emitting status heartbeats.
 	uc.EnsureStatusSubscription(ctx, deviceID)
+	uc.EnsureUNSToNATSMirror(ctx, deviceID)
 
 	return &LoginResponse{
 		JwtToken:            jwtToken,
@@ -1068,6 +1076,7 @@ func (uc *InstanceUsecase) correlateResponseByTraceId(ctx context.Context, devic
 			_ = uc.syncDataModelActionResult(ctx, &actionWithStatus, []byte(resultPayload))
 			_ = uc.syncStreamProcessorActionResult(ctx, &actionWithStatus, []byte(resultPayload))
 		}
+		uc.RecordNATSMirrorDeploySuccess(ctx, &actionWithStatus)
 	}
 
 	// 7. Mark tracking as completed
@@ -1158,6 +1167,8 @@ func (uc *InstanceUsecase) correlateResponseByActionUUID(ctx context.Context, te
 	// This mirrors the logic in correlateResponseByTraceId to ensure DB persistence
 	// regardless of which correlation method (trace_id vs actionUUID) is used
 	if finalStatus == models.ActionStatusCompleted && action != nil {
+		actionWithStatus := *action
+		actionWithStatus.Status = finalStatus
 		syncMsg := deviceMsg
 		if syncMsg == nil {
 			syncMsg, err = uc.store.Messages().GetByID(ctx, messageID)
@@ -1166,13 +1177,11 @@ func (uc *InstanceUsecase) correlateResponseByActionUUID(ctx context.Context, te
 			}
 		}
 		if syncMsg != nil {
-			// Create a copy of action with updated status for sync
-			actionWithStatus := *action
-			actionWithStatus.Status = finalStatus
 			_ = uc.syncProtocolConverterActionResult(ctx, &actionWithStatus, []byte(syncMsg.Content))
 			_ = uc.syncDataModelActionResult(ctx, &actionWithStatus, []byte(syncMsg.Content))
 			_ = uc.syncStreamProcessorActionResult(ctx, &actionWithStatus, []byte(syncMsg.Content))
 		}
+		uc.RecordNATSMirrorDeploySuccess(ctx, &actionWithStatus)
 	}
 
 	return nil

--- a/device-management/internal/biz/instance.go
+++ b/device-management/internal/biz/instance.go
@@ -1077,6 +1077,8 @@ func (uc *InstanceUsecase) correlateResponseByTraceId(ctx context.Context, devic
 			_ = uc.syncStreamProcessorActionResult(ctx, &actionWithStatus, []byte(resultPayload))
 		}
 		uc.RecordNATSMirrorDeploySuccess(ctx, &actionWithStatus)
+	} else if action != nil {
+		uc.HandleNATSMirrorActionFailure(ctx, action, finalStatus, errorMessage)
 	}
 
 	// 7. Mark tracking as completed
@@ -1182,6 +1184,8 @@ func (uc *InstanceUsecase) correlateResponseByActionUUID(ctx context.Context, te
 			_ = uc.syncStreamProcessorActionResult(ctx, &actionWithStatus, []byte(syncMsg.Content))
 		}
 		uc.RecordNATSMirrorDeploySuccess(ctx, &actionWithStatus)
+	} else if action != nil {
+		uc.HandleNATSMirrorActionFailure(ctx, action, finalStatus, errorMessage)
 	}
 
 	return nil

--- a/device-management/internal/biz/nats_mirror.go
+++ b/device-management/internal/biz/nats_mirror.go
@@ -317,3 +317,27 @@ func (uc *InstanceUsecase) recordNATSMirrorApplySuccess(ctx context.Context, act
 		fmt.Printf("Warning: SetNATSMirrorApplied for device %s: %v\n", action.DeviceId, err)
 	}
 }
+
+func isNATSMirrorEditNotFoundError(errorMessage string) bool {
+	return strings.Contains(strings.ToLower(errorMessage), "not found")
+}
+
+// HandleNATSMirrorActionFailure clears mirror state when an edit fails because the DFC is gone on the edge,
+// then queues deploy (if NATS URLs are configured and no mirror action is inflight).
+func (uc *InstanceUsecase) HandleNATSMirrorActionFailure(ctx context.Context, action *models.Action, finalStatus models.ActionStatus, errorMessage string) {
+	if uc == nil || action == nil || !IsNATSMirrorEditAction(action) {
+		return
+	}
+	if finalStatus != models.ActionStatusFailed {
+		return
+	}
+	if !isNATSMirrorEditNotFoundError(errorMessage) {
+		return
+	}
+	if err := uc.store.Devices().ClearNATSMirrorApplied(ctx, action.DeviceId); err != nil {
+		fmt.Printf("Warning: ClearNATSMirrorApplied for device %s after edit not found: %v\n", action.DeviceId, err)
+		return
+	}
+	fmt.Printf("Info: NATS mirror edit not found on device %s; cleared mirror state and re-queuing deploy\n", action.DeviceId)
+	uc.ensureNATSMirrorForDevice(ctx, action.DeviceId)
+}

--- a/device-management/internal/biz/nats_mirror.go
+++ b/device-management/internal/biz/nats_mirror.go
@@ -262,17 +262,43 @@ func (uc *InstanceUsecase) ReconcileNATSMirrorFleet(ctx context.Context) {
 		return
 	}
 	for _, ref := range refs {
+		if ctx.Err() != nil {
+			return
+		}
 		deviceCtx := middleware.SetTenantID(ctx, ref.TenantID)
 		uc.ensureNATSMirrorForDevice(deviceCtx, ref.ID)
 	}
 }
 
-// StartNATSMirrorFleetReconcile runs ReconcileNATSMirrorFleet once after a short delay (DB ready).
-func (uc *InstanceUsecase) StartNATSMirrorFleetReconcile() {
+// StartNATSMirrorFleetReconcile schedules one fleet reconcile after startup (parent ctx from app lifecycle).
+func (uc *InstanceUsecase) StartNATSMirrorFleetReconcile(ctx context.Context) {
+	if uc == nil || ctx == nil {
+		return
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	uc.natsMirrorReconcileCancel = cancel
+	uc.natsMirrorReconcileWG.Add(1)
 	go func() {
-		time.Sleep(3 * time.Second)
-		uc.ReconcileNATSMirrorFleet(context.Background())
+		defer uc.natsMirrorReconcileWG.Done()
+		timer := time.NewTimer(3 * time.Second)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		}
+		uc.ReconcileNATSMirrorFleet(ctx)
 	}()
+}
+
+// StopNATSMirrorFleetReconcile cancels an in-flight fleet reconcile (call from app shutdown).
+func (uc *InstanceUsecase) StopNATSMirrorFleetReconcile() {
+	if uc == nil || uc.natsMirrorReconcileCancel == nil {
+		return
+	}
+	uc.natsMirrorReconcileCancel()
+	uc.natsMirrorReconcileWG.Wait()
+	uc.natsMirrorReconcileCancel = nil
 }
 
 // IsNATSMirrorDeployAction reports whether the queued action deploys the platform UNS→NATS mirror DFC.

--- a/device-management/internal/biz/nats_mirror.go
+++ b/device-management/internal/biz/nats_mirror.go
@@ -1,0 +1,319 @@
+package biz
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/types/known/anypb"
+	"gopkg.in/yaml.v3"
+
+	"github.com/artpark-hub/taksa-platform/device-management/internal/conf"
+	"github.com/artpark-hub/taksa-platform/device-management/internal/middleware"
+	"github.com/artpark-hub/taksa-platform/device-management/internal/models"
+)
+
+const (
+	// natsMirrorDataFlowName is the stable umh-core data flow component name (idempotent deploy).
+	natsMirrorDataFlowName = "UNS-to-NATS-mirror"
+	// actionTypeDeployDataFlow must match umh-core models.DeployDataFlowComponent ("deploy-data-flow-component").
+	actionTypeDeployDataFlow = "deploy-data-flow-component"
+	// actionTypeEditDataFlow must match umh-core models.EditDataFlowComponent ("edit-data-flow-component").
+	actionTypeEditDataFlow = "edit-data-flow-component"
+	// natsMirrorPayloadTypeURL is stored with the queued action JSON; umh-core consumes raw JSON bytes.
+	natsMirrorPayloadTypeURL = "type.googleapis.com/taksa.edge.NATSMirrorDeployPayload"
+)
+
+func parseNatsMirrorURLs(dep *conf.Deployment) []string {
+	if dep == nil {
+		return nil
+	}
+	raw := strings.TrimSpace(dep.GetNatsMirrorUrls())
+	if raw == "" {
+		return nil
+	}
+	var out []string
+	for _, p := range strings.Split(raw, ",") {
+		u := strings.TrimSpace(p)
+		if u != "" {
+			out = append(out, u)
+		}
+	}
+	return out
+}
+
+// NATSMirrorConfigFingerprint returns a stable hash of the configured NATS URL list.
+func NATSMirrorConfigFingerprint(urls []string) string {
+	if len(urls) == 0 {
+		return ""
+	}
+	sorted := append([]string(nil), urls...)
+	sort.Strings(sorted)
+	sum := sha256.Sum256([]byte(strings.Join(sorted, ",")))
+	return hex.EncodeToString(sum[:])
+}
+
+// natsMirrorComponentUUID matches umh-core dataflowcomponentserviceconfig.GenerateUUIDFromName.
+func natsMirrorComponentUUID() string {
+	return uuid.NewSHA1(uuid.NameSpaceDNS, []byte(natsMirrorDataFlowName)).String()
+}
+
+func buildNATSMirrorCustomDFC(tenantID, deviceID string, natsURLs []string) (map[string]interface{}, error) {
+	if len(natsURLs) == 0 {
+		return nil, fmt.Errorf("no NATS URLs")
+	}
+
+	unsRoot := map[string]interface{}{
+		"uns": map[string]interface{}{
+			"consumer_group": "dm_uns_nats_mirror_" + strings.ReplaceAll(deviceID, "-", ""),
+			"umh_topic":      ".*",
+		},
+	}
+	unsYAML, err := yaml.Marshal(unsRoot)
+	if err != nil {
+		return nil, fmt.Errorf("marshal uns yaml: %w", err)
+	}
+
+	subject := fmt.Sprintf(
+		`%s.%s.${! meta("umh_topic").re_replace("^umh\\.v1", "uns.v1") }`,
+		tenantID,
+		deviceID,
+	)
+	natsRoot := map[string]interface{}{
+		"nats": map[string]interface{}{
+			"urls":           natsURLs,
+			"subject":        subject,
+			"max_reconnects": -1,
+		},
+	}
+	natsYAML, err := yaml.Marshal(natsRoot)
+	if err != nil {
+		return nil, fmt.Errorf("marshal nats yaml: %w", err)
+	}
+
+	procData := "mapping: |\n  root = this\n"
+
+	return map[string]interface{}{
+		"inputs": map[string]interface{}{
+			"type": "uns",
+			"data": string(unsYAML),
+		},
+		"outputs": map[string]interface{}{
+			"type": "nats",
+			"data": string(natsYAML),
+		},
+		"pipeline": map[string]interface{}{
+			"processors": map[string]interface{}{
+				"0": map[string]interface{}{
+					"type": "bloblang",
+					"data": procData,
+				},
+			},
+		},
+		"rawYAML": map[string]interface{}{
+			"data": "buffer:\n  none: {}\n",
+		},
+	}, nil
+}
+
+// buildNATSMirrorDeployActionPayload builds the JSON body umh-core expects for deploy-data-flow-component.
+func buildNATSMirrorDeployActionPayload(tenantID, deviceID string, natsURLs []string) (map[string]interface{}, error) {
+	cdfc, err := buildNATSMirrorCustomDFC(tenantID, deviceID, natsURLs)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{
+		"name":              natsMirrorDataFlowName,
+		"meta":              map[string]interface{}{"type": "custom"},
+		"state":             "active",
+		"ignoreHealthCheck": false,
+		"payload": map[string]interface{}{
+			"customDataFlowComponent": cdfc,
+		},
+	}, nil
+}
+
+// buildNATSMirrorEditActionPayload builds the JSON body umh-core expects for edit-data-flow-component.
+func buildNATSMirrorEditActionPayload(tenantID, deviceID string, natsURLs []string) (map[string]interface{}, error) {
+	cdfc, err := buildNATSMirrorCustomDFC(tenantID, deviceID, natsURLs)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{
+		"uuid":              natsMirrorComponentUUID(),
+		"name":              natsMirrorDataFlowName,
+		"meta":              map[string]interface{}{"type": "custom"},
+		"state":             "active",
+		"ignoreHealthCheck": false,
+		"payload": map[string]interface{}{
+			"customDataFlowComponent": cdfc,
+		},
+	}, nil
+}
+
+func (uc *InstanceUsecase) queueNATSMirrorAction(ctx context.Context, deviceID, actionType string, inner map[string]interface{}) {
+	payloadJSON, err := json.Marshal(inner)
+	if err != nil {
+		fmt.Printf("Warning: marshal NATS mirror %s for device %s: %v\n", actionType, deviceID, err)
+		return
+	}
+	_, err = uc.actionUc.QueueAction(ctx, &QueueActionRequest{
+		DeviceID:   deviceID,
+		ActionType: actionType,
+		Payload: &anypb.Any{
+			TypeUrl: natsMirrorPayloadTypeURL,
+			Value:   payloadJSON,
+		},
+		MaxRetries: 3,
+		TTLSeconds: 3600,
+	})
+	if err != nil {
+		fmt.Printf("Warning: failed to queue NATS mirror %s for device %s: %v\n", actionType, deviceID, err)
+	}
+}
+
+func (uc *InstanceUsecase) ensureNATSMirrorForDevice(ctx context.Context, deviceID string) {
+	if uc == nil || uc.actionUc == nil || uc.store == nil {
+		return
+	}
+	if deviceID == "" {
+		return
+	}
+	tenantID := middleware.GetTenantID(ctx)
+	if tenantID == "" {
+		return
+	}
+	natsURLs := parseNatsMirrorURLs(uc.deployment)
+	if len(natsURLs) == 0 {
+		return
+	}
+	currentFP := NATSMirrorConfigFingerprint(natsURLs)
+
+	deployed, err := uc.store.Devices().NATSMirrorDeployed(ctx, deviceID)
+	if err != nil {
+		fmt.Printf("Warning: NATSMirrorDeployed check failed for device %s: %v\n", deviceID, err)
+		return
+	}
+
+	if deployed {
+		storedFP, err := uc.store.Devices().GetNATSMirrorConfigFingerprint(ctx, deviceID)
+		if err != nil {
+			fmt.Printf("Warning: GetNATSMirrorConfigFingerprint for device %s: %v\n", deviceID, err)
+			return
+		}
+		if storedFP == currentFP {
+			return
+		}
+	}
+
+	inflight, err := uc.store.Actions().NATSMirrorActionInflight(ctx, tenantID, deviceID)
+	if err != nil {
+		fmt.Printf("Warning: NATSMirrorActionInflight failed for device %s: %v\n", deviceID, err)
+		return
+	}
+	if inflight {
+		return
+	}
+
+	if !deployed {
+		inner, err := buildNATSMirrorDeployActionPayload(tenantID, deviceID, natsURLs)
+		if err != nil {
+			fmt.Printf("Warning: build NATS mirror deploy payload for device %s: %v\n", deviceID, err)
+			return
+		}
+		uc.queueNATSMirrorAction(ctx, deviceID, actionTypeDeployDataFlow, inner)
+		return
+	}
+
+	inner, err := buildNATSMirrorEditActionPayload(tenantID, deviceID, natsURLs)
+	if err != nil {
+		fmt.Printf("Warning: build NATS mirror edit payload for device %s: %v\n", deviceID, err)
+		return
+	}
+	uc.queueNATSMirrorAction(ctx, deviceID, actionTypeEditDataFlow, inner)
+}
+
+// EnsureUNSToNATSMirror queues deploy or edit so UNS is mirrored to NATS with subject pattern
+// <tenant_id>.<device_id>.uns.v1.<rest> (only the leading umh.v1 segment is rewritten).
+func (uc *InstanceUsecase) EnsureUNSToNATSMirror(ctx context.Context, deviceID string) {
+	uc.ensureNATSMirrorForDevice(ctx, deviceID)
+}
+
+// ReconcileNATSMirrorFleet queues mirror deploy/edit for all devices whose stored config fingerprint
+// differs from deployment.nats_mirror_urls (e.g. after .env or config.yaml change and DM restart).
+func (uc *InstanceUsecase) ReconcileNATSMirrorFleet(ctx context.Context) {
+	if uc == nil || uc.store == nil {
+		return
+	}
+	natsURLs := parseNatsMirrorURLs(uc.deployment)
+	if len(natsURLs) == 0 {
+		return
+	}
+	currentFP := NATSMirrorConfigFingerprint(natsURLs)
+	refs, err := uc.store.Devices().ListNATSMirrorDevicesNeedingUpdate(ctx, currentFP)
+	if err != nil {
+		fmt.Printf("Warning: ListNATSMirrorDevicesNeedingUpdate: %v\n", err)
+		return
+	}
+	for _, ref := range refs {
+		deviceCtx := middleware.SetTenantID(ctx, ref.TenantID)
+		uc.ensureNATSMirrorForDevice(deviceCtx, ref.ID)
+	}
+}
+
+// StartNATSMirrorFleetReconcile runs ReconcileNATSMirrorFleet once after a short delay (DB ready).
+func (uc *InstanceUsecase) StartNATSMirrorFleetReconcile() {
+	go func() {
+		time.Sleep(3 * time.Second)
+		uc.ReconcileNATSMirrorFleet(context.Background())
+	}()
+}
+
+// IsNATSMirrorDeployAction reports whether the queued action deploys the platform UNS→NATS mirror DFC.
+func IsNATSMirrorDeployAction(action *models.Action) bool {
+	if action == nil || action.Type != actionTypeDeployDataFlow {
+		return false
+	}
+	return natsMirrorActionPayloadMatches(action)
+}
+
+// IsNATSMirrorEditAction reports whether the queued action edits the platform UNS→NATS mirror DFC.
+func IsNATSMirrorEditAction(action *models.Action) bool {
+	if action == nil || action.Type != actionTypeEditDataFlow {
+		return false
+	}
+	return natsMirrorActionPayloadMatches(action)
+}
+
+// IsNATSMirrorMirrorAction reports deploy or edit of UNS-to-NATS-mirror.
+func IsNATSMirrorMirrorAction(action *models.Action) bool {
+	return IsNATSMirrorDeployAction(action) || IsNATSMirrorEditAction(action)
+}
+
+func natsMirrorActionPayloadMatches(action *models.Action) bool {
+	if action.Payload == nil || len(action.Payload.Value) == 0 {
+		return false
+	}
+	return strings.Contains(string(action.Payload.Value), natsMirrorDataFlowName)
+}
+
+// RecordNATSMirrorDeploySuccess persists mirror success on the device row (survives actions cleanup).
+func (uc *InstanceUsecase) RecordNATSMirrorDeploySuccess(ctx context.Context, action *models.Action) {
+	uc.recordNATSMirrorApplySuccess(ctx, action)
+}
+
+func (uc *InstanceUsecase) recordNATSMirrorApplySuccess(ctx context.Context, action *models.Action) {
+	if uc == nil || uc.store == nil || action == nil || !IsNATSMirrorMirrorAction(action) {
+		return
+	}
+	fp := NATSMirrorConfigFingerprint(parseNatsMirrorURLs(uc.deployment))
+	if err := uc.store.Devices().SetNATSMirrorApplied(ctx, action.DeviceId, time.Now(), fp); err != nil {
+		fmt.Printf("Warning: SetNATSMirrorApplied for device %s: %v\n", action.DeviceId, err)
+	}
+}

--- a/device-management/internal/biz/nats_mirror_test.go
+++ b/device-management/internal/biz/nats_mirror_test.go
@@ -44,6 +44,16 @@ func TestBuildNATSMirrorEditActionPayload_hasUUID(t *testing.T) {
 	}
 }
 
+func TestIsNATSMirrorEditNotFoundError(t *testing.T) {
+	msg := `edit(UNS-to-NATS-mirror): failed to edit dataflow component: dataflow component with UUID 95d80fc0-d68b-5f99-865e-4de41b9ad51e not found`
+	if !isNATSMirrorEditNotFoundError(msg) {
+		t.Fatal("expected not found")
+	}
+	if isNATSMirrorEditNotFoundError("connection refused") {
+		t.Fatal("expected false for unrelated error")
+	}
+}
+
 func TestNATSMirrorConfigFingerprint_orderIndependent(t *testing.T) {
 	a := NATSMirrorConfigFingerprint([]string{"nats://b:4222", "nats://a:4222"})
 	b := NATSMirrorConfigFingerprint([]string{"nats://a:4222", "nats://b:4222"})

--- a/device-management/internal/biz/nats_mirror_test.go
+++ b/device-management/internal/biz/nats_mirror_test.go
@@ -1,0 +1,57 @@
+package biz
+
+import (
+	"testing"
+)
+
+func TestBuildNATSMirrorDeployActionPayload_shape(t *testing.T) {
+	m, err := buildNATSMirrorDeployActionPayload("tenant-a", "dev-1", []string{"nats://127.0.0.1:4222"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m["name"] != natsMirrorDataFlowName {
+		t.Fatalf("name: got %v", m["name"])
+	}
+	meta, ok := m["meta"].(map[string]interface{})
+	if !ok || meta["type"] != "custom" {
+		t.Fatalf("meta: %#v", m["meta"])
+	}
+	pl, ok := m["payload"].(map[string]interface{})
+	if !ok {
+		t.Fatal("missing payload")
+	}
+	cdfc, ok := pl["customDataFlowComponent"].(map[string]interface{})
+	if !ok {
+		t.Fatal("missing customDataFlowComponent")
+	}
+	for _, k := range []string{"inputs", "outputs", "pipeline", "rawYAML"} {
+		if _, ok := cdfc[k]; !ok {
+			t.Fatalf("missing cdfc key %s", k)
+		}
+	}
+}
+
+func TestBuildNATSMirrorEditActionPayload_hasUUID(t *testing.T) {
+	m, err := buildNATSMirrorEditActionPayload("tenant-a", "dev-1", []string{"nats://127.0.0.1:4222"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m["uuid"] != natsMirrorComponentUUID() {
+		t.Fatalf("uuid: got %v want %s", m["uuid"], natsMirrorComponentUUID())
+	}
+	if m["name"] != natsMirrorDataFlowName {
+		t.Fatalf("name: got %v", m["name"])
+	}
+}
+
+func TestNATSMirrorConfigFingerprint_orderIndependent(t *testing.T) {
+	a := NATSMirrorConfigFingerprint([]string{"nats://b:4222", "nats://a:4222"})
+	b := NATSMirrorConfigFingerprint([]string{"nats://a:4222", "nats://b:4222"})
+	if a == "" || a != b {
+		t.Fatalf("fingerprints differ: %q vs %q", a, b)
+	}
+	c := NATSMirrorConfigFingerprint([]string{"nats://a:4222"})
+	if a == c {
+		t.Fatal("expected different fingerprint for different URL set")
+	}
+}

--- a/device-management/internal/conf/conf.proto
+++ b/device-management/internal/conf/conf.proto
@@ -29,6 +29,9 @@ message DeviceStatusSubscription {
 message Deployment {
   string base_url = 1;              // API base URL (e.g., http://localhost:8000)
   string umh_core_docker_image = 2; // UMH-Core docker image URI
+  // Comma-separated NATS broker URLs (e.g. nats://host:4222) for auto-deployed UNS→NATS mirror on device login.
+  // Empty disables EnsureUNSToNATSMirror (no deploy-data-flow-component is queued).
+  string nats_mirror_urls = 3;
 }
 
 message Server {

--- a/device-management/internal/service/devicemgmt.go
+++ b/device-management/internal/service/devicemgmt.go
@@ -1225,7 +1225,7 @@ func (s *DeviceMgmtService) DeployDataFlowComponent(ctx context.Context, req *v1
 
 	action, err := s.actionUc.QueueAction(ctx, &biz.QueueActionRequest{
 		DeviceID:   req.DeviceId,
-		ActionType: "deploy_data_flow_component",
+		ActionType: "deploy-data-flow-component",
 		Payload:    payload,
 		MaxRetries: 3,
 		TTLSeconds: 3600,
@@ -1255,7 +1255,7 @@ func (s *DeviceMgmtService) EditDataFlowComponent(ctx context.Context, req *v1.E
 
 	action, err := s.actionUc.QueueAction(ctx, &biz.QueueActionRequest{
 		DeviceID:   req.DeviceId,
-		ActionType: "edit_data_flow_component",
+		ActionType: "edit-data-flow-component",
 		Payload:    payload,
 		MaxRetries: 3,
 		TTLSeconds: 3600,
@@ -1285,7 +1285,7 @@ func (s *DeviceMgmtService) GetDataFlowComponent(ctx context.Context, req *v1.Ge
 
 	action, err := s.actionUc.QueueAction(ctx, &biz.QueueActionRequest{
 		DeviceID:   req.DeviceId,
-		ActionType: "get_data_flow_component",
+		ActionType: "get-data-flow-component",
 		Payload:    payload,
 		MaxRetries: 3,
 		TTLSeconds: 1800,
@@ -1315,7 +1315,7 @@ func (s *DeviceMgmtService) DeleteDataFlowComponent(ctx context.Context, req *v1
 
 	action, err := s.actionUc.QueueAction(ctx, &biz.QueueActionRequest{
 		DeviceID:   req.DeviceId,
-		ActionType: "delete_data_flow_component",
+		ActionType: "delete-data-flow-component",
 		Payload:    payload,
 		MaxRetries: 3,
 		TTLSeconds: 3600,

--- a/device-management/internal/storage/action.go
+++ b/device-management/internal/storage/action.go
@@ -56,6 +56,12 @@ type ActionStore interface {
 
 	// DeleteQueuedSubscribe removes a pending QUEUED subscribe for the device (if any).
 	DeleteQueuedSubscribe(ctx context.Context, tenantID, deviceID string) (bool, error)
+
+	// NATSMirrorDeployInflight returns whether a UNS-to-NATS-mirror deploy is queued or delivered but not finished.
+	NATSMirrorDeployInflight(ctx context.Context, tenantID, deviceID string) (bool, error)
+
+	// NATSMirrorActionInflight returns whether a UNS-to-NATS-mirror deploy or edit is queued or delivered but not finished.
+	NATSMirrorActionInflight(ctx context.Context, tenantID, deviceID string) (bool, error)
 }
 
 // ActionListFilter defines filtering and pagination for action listing

--- a/device-management/internal/storage/action.go
+++ b/device-management/internal/storage/action.go
@@ -57,10 +57,10 @@ type ActionStore interface {
 	// DeleteQueuedSubscribe removes a pending QUEUED subscribe for the device (if any).
 	DeleteQueuedSubscribe(ctx context.Context, tenantID, deviceID string) (bool, error)
 
-	// NATSMirrorDeployInflight returns whether a UNS-to-NATS-mirror deploy is queued or delivered but not finished.
+	// NATSMirrorDeployInflight returns whether a UNS-to-NATS-mirror deploy is in progress (queued, delivered, or processing).
 	NATSMirrorDeployInflight(ctx context.Context, tenantID, deviceID string) (bool, error)
 
-	// NATSMirrorActionInflight returns whether a UNS-to-NATS-mirror deploy or edit is queued or delivered but not finished.
+	// NATSMirrorActionInflight returns whether a UNS-to-NATS-mirror deploy or edit is in progress.
 	NATSMirrorActionInflight(ctx context.Context, tenantID, deviceID string) (bool, error)
 }
 

--- a/device-management/internal/storage/device.go
+++ b/device-management/internal/storage/device.go
@@ -55,7 +55,10 @@ type DeviceStore interface {
 	// SetNATSMirrorApplied records successful deploy or edit of UNS-to-NATS-mirror on the device row.
 	SetNATSMirrorApplied(ctx context.Context, deviceID string, deployedAt time.Time, configFingerprint string) error
 
-	// ListNATSMirrorDevicesNeedingUpdate returns devices with mirror deployed but a different config fingerprint.
+	// ClearNATSMirrorApplied clears mirror deploy state (e.g. after edit fails because DFC missing on edge).
+	ClearNATSMirrorApplied(ctx context.Context, deviceID string) error
+
+	// ListNATSMirrorDevicesNeedingUpdate returns devices needing mirror deploy or edit (never applied or stale fingerprint).
 	ListNATSMirrorDevicesNeedingUpdate(ctx context.Context, currentFingerprint string) ([]NATSMirrorDeviceRef, error)
 }
 

--- a/device-management/internal/storage/device.go
+++ b/device-management/internal/storage/device.go
@@ -45,6 +45,24 @@ type DeviceStore interface {
 
 	// UpdateAuthTokenExpiresAt updates only the auth_token_expires_at timestamp
 	UpdateAuthTokenExpiresAt(ctx context.Context, id string, timestamp time.Time) error
+
+	// NATSMirrorDeployed returns true if UNS-to-NATS-mirror was successfully deployed on this device.
+	NATSMirrorDeployed(ctx context.Context, deviceID string) (bool, error)
+
+	// GetNATSMirrorConfigFingerprint returns the fingerprint of NATS URLs last applied (empty if never set).
+	GetNATSMirrorConfigFingerprint(ctx context.Context, deviceID string) (string, error)
+
+	// SetNATSMirrorApplied records successful deploy or edit of UNS-to-NATS-mirror on the device row.
+	SetNATSMirrorApplied(ctx context.Context, deviceID string, deployedAt time.Time, configFingerprint string) error
+
+	// ListNATSMirrorDevicesNeedingUpdate returns devices with mirror deployed but a different config fingerprint.
+	ListNATSMirrorDevicesNeedingUpdate(ctx context.Context, currentFingerprint string) ([]NATSMirrorDeviceRef, error)
+}
+
+// NATSMirrorDeviceRef identifies a device for fleet NATS mirror reconciliation.
+type NATSMirrorDeviceRef struct {
+	ID       string
+	TenantID string
 }
 
 // DeviceListFilter defines filtering and pagination for device listing

--- a/device-management/internal/storage/postgres/action.go
+++ b/device-management/internal/storage/postgres/action.go
@@ -597,28 +597,60 @@ func (s *ActionStore) listActions(ctx context.Context, whereClause string, args 
 	return actions, nil
 }
 
-// NATSMirrorDeployInflight reports whether a UNS-to-NATS mirror deploy is queued or delivered.
+const natsMirrorNameMarker = "%UNS-to-NATS-mirror%"
+
+// NATSMirrorDeployInflight reports whether a UNS-to-NATS mirror deploy is queued, delivered, or processing.
 func (s *ActionStore) NATSMirrorDeployInflight(ctx context.Context, tenantID, deviceID string) (bool, error) {
-	return s.NATSMirrorActionInflight(ctx, tenantID, deviceID)
+	return s.natsMirrorInflight(ctx, tenantID, deviceID, "deploy-data-flow-component")
 }
 
-// NATSMirrorActionInflight reports whether a UNS-to-NATS mirror deploy or edit is queued or delivered.
+// NATSMirrorActionInflight reports whether a UNS-to-NATS mirror deploy or edit is queued, delivered, or processing.
 func (s *ActionStore) NATSMirrorActionInflight(ctx context.Context, tenantID, deviceID string) (bool, error) {
 	if tenantID == "" || deviceID == "" {
 		return false, ErrInvalidInput
 	}
-	const nameMarker = "%UNS-to-NATS-mirror%"
+	const (
+		deployType = "deploy-data-flow-component"
+		editType   = "edit-data-flow-component"
+	)
 	var inflight bool
 	err := s.db.QueryRowContext(ctx, `
 SELECT EXISTS (
   SELECT 1 FROM actions
   WHERE tenant_id = $1 AND device_id = $2
-    AND action_type IN ('deploy-data-flow-component', 'edit-data-flow-component')
-    AND payload_data LIKE $3
-    AND status IN (1, 2)
-)`, tenantID, deviceID, nameMarker).Scan(&inflight)
+    AND action_type IN ($3, $4)
+    AND payload_data LIKE $5
+    AND status IN ($6, $7, $8)
+)`, tenantID, deviceID, deployType, editType, natsMirrorNameMarker,
+		int(models.ActionStatusQueued),
+		int(models.ActionStatusDelivered),
+		int(models.ActionStatusProcessing),
+	).Scan(&inflight)
 	if err != nil {
 		return false, fmt.Errorf("nats mirror action inflight query: %w", err)
+	}
+	return inflight, nil
+}
+
+func (s *ActionStore) natsMirrorInflight(ctx context.Context, tenantID, deviceID, actionType string) (bool, error) {
+	if tenantID == "" || deviceID == "" || actionType == "" {
+		return false, ErrInvalidInput
+	}
+	var inflight bool
+	err := s.db.QueryRowContext(ctx, `
+SELECT EXISTS (
+  SELECT 1 FROM actions
+  WHERE tenant_id = $1 AND device_id = $2
+    AND action_type = $3
+    AND payload_data LIKE $4
+    AND status IN ($5, $6, $7)
+)`, tenantID, deviceID, actionType, natsMirrorNameMarker,
+		int(models.ActionStatusQueued),
+		int(models.ActionStatusDelivered),
+		int(models.ActionStatusProcessing),
+	).Scan(&inflight)
+	if err != nil {
+		return false, fmt.Errorf("nats mirror inflight query: %w", err)
 	}
 	return inflight, nil
 }

--- a/device-management/internal/storage/postgres/action.go
+++ b/device-management/internal/storage/postgres/action.go
@@ -596,3 +596,29 @@ func (s *ActionStore) listActions(ctx context.Context, whereClause string, args 
 
 	return actions, nil
 }
+
+// NATSMirrorDeployInflight reports whether a UNS-to-NATS mirror deploy is queued or delivered.
+func (s *ActionStore) NATSMirrorDeployInflight(ctx context.Context, tenantID, deviceID string) (bool, error) {
+	return s.NATSMirrorActionInflight(ctx, tenantID, deviceID)
+}
+
+// NATSMirrorActionInflight reports whether a UNS-to-NATS mirror deploy or edit is queued or delivered.
+func (s *ActionStore) NATSMirrorActionInflight(ctx context.Context, tenantID, deviceID string) (bool, error) {
+	if tenantID == "" || deviceID == "" {
+		return false, ErrInvalidInput
+	}
+	const nameMarker = "%UNS-to-NATS-mirror%"
+	var inflight bool
+	err := s.db.QueryRowContext(ctx, `
+SELECT EXISTS (
+  SELECT 1 FROM actions
+  WHERE tenant_id = $1 AND device_id = $2
+    AND action_type IN ('deploy-data-flow-component', 'edit-data-flow-component')
+    AND payload_data LIKE $3
+    AND status IN (1, 2)
+)`, tenantID, deviceID, nameMarker).Scan(&inflight)
+	if err != nil {
+		return false, fmt.Errorf("nats mirror action inflight query: %w", err)
+	}
+	return inflight, nil
+}

--- a/device-management/internal/storage/postgres/device.go
+++ b/device-management/internal/storage/postgres/device.go
@@ -784,6 +784,101 @@ func (s *DeviceStore) UpdateLastLogin(ctx context.Context, id string, timestamp 
 	return nil
 }
 
+// NATSMirrorDeployed reports whether UNS-to-NATS-mirror was successfully deployed (persistent).
+func (s *DeviceStore) NATSMirrorDeployed(ctx context.Context, deviceID string) (bool, error) {
+	if deviceID == "" {
+		return false, ErrInvalidInput
+	}
+	query := "SELECT nats_mirror_deployed_at IS NOT NULL FROM devices WHERE id = $1"
+	args := []interface{}{deviceID}
+	if tenantID := middleware.GetTenantID(ctx); tenantID != "" {
+		query = "SELECT nats_mirror_deployed_at IS NOT NULL FROM devices WHERE id = $1 AND tenant_id = $2"
+		args = append(args, tenantID)
+	}
+	var deployed bool
+	if err := s.db.QueryRowContext(ctx, query, args...).Scan(&deployed); err != nil {
+		if err == sql.ErrNoRows {
+			return false, ErrNotFound
+		}
+		return false, fmt.Errorf("nats mirror deployed check: %w", err)
+	}
+	return deployed, nil
+}
+
+// GetNATSMirrorConfigFingerprint returns the config fingerprint last applied on the device (empty if unset).
+func (s *DeviceStore) GetNATSMirrorConfigFingerprint(ctx context.Context, deviceID string) (string, error) {
+	if deviceID == "" {
+		return "", ErrInvalidInput
+	}
+	query := "SELECT COALESCE(nats_mirror_config_fingerprint, '') FROM devices WHERE id = $1"
+	args := []interface{}{deviceID}
+	if tenantID := middleware.GetTenantID(ctx); tenantID != "" {
+		query = "SELECT COALESCE(nats_mirror_config_fingerprint, '') FROM devices WHERE id = $1 AND tenant_id = $2"
+		args = append(args, tenantID)
+	}
+	var fp string
+	if err := s.db.QueryRowContext(ctx, query, args...).Scan(&fp); err != nil {
+		if err == sql.ErrNoRows {
+			return "", ErrNotFound
+		}
+		return "", fmt.Errorf("nats mirror config fingerprint: %w", err)
+	}
+	return fp, nil
+}
+
+// SetNATSMirrorApplied records successful UNS-to-NATS-mirror deploy or edit on the device row.
+func (s *DeviceStore) SetNATSMirrorApplied(ctx context.Context, deviceID string, deployedAt time.Time, configFingerprint string) error {
+	if deviceID == "" {
+		return ErrInvalidInput
+	}
+	query := `UPDATE devices SET nats_mirror_deployed_at = $1, nats_mirror_config_fingerprint = $2 WHERE id = $3`
+	args := []interface{}{deployedAt.UTC().Format(time.RFC3339), configFingerprint, deviceID}
+	if tenantID := middleware.GetTenantID(ctx); tenantID != "" {
+		query = `UPDATE devices SET nats_mirror_deployed_at = $1, nats_mirror_config_fingerprint = $2 WHERE id = $3 AND tenant_id = $4`
+		args = append(args, tenantID)
+	}
+	result, err := s.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("set nats mirror applied: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("set nats mirror applied rows: %w", err)
+	}
+	if rows == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ListNATSMirrorDevicesNeedingUpdate lists devices with mirror deployed but stale or missing fingerprint.
+func (s *DeviceStore) ListNATSMirrorDevicesNeedingUpdate(ctx context.Context, currentFingerprint string) ([]storage.NATSMirrorDeviceRef, error) {
+	if currentFingerprint == "" {
+		return nil, ErrInvalidInput
+	}
+	rows, err := s.db.QueryContext(ctx, `
+SELECT id, tenant_id FROM devices
+WHERE nats_mirror_deployed_at IS NOT NULL
+  AND (nats_mirror_config_fingerprint IS NULL OR nats_mirror_config_fingerprint <> $1)
+ORDER BY tenant_id, id`, currentFingerprint)
+	if err != nil {
+		return nil, fmt.Errorf("list nats mirror devices needing update: %w", err)
+	}
+	defer rows.Close()
+	var out []storage.NATSMirrorDeviceRef
+	for rows.Next() {
+		var ref storage.NATSMirrorDeviceRef
+		if err := rows.Scan(&ref.ID, &ref.TenantID); err != nil {
+			return nil, fmt.Errorf("scan nats mirror device ref: %w", err)
+		}
+		out = append(out, ref)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate nats mirror device refs: %w", err)
+	}
+	return out, nil
+}
+
 // Delete removes a device
 func (s *DeviceStore) Delete(ctx context.Context, id string) error {
 	if id == "" {

--- a/device-management/internal/storage/postgres/device.go
+++ b/device-management/internal/storage/postgres/device.go
@@ -851,15 +851,41 @@ func (s *DeviceStore) SetNATSMirrorApplied(ctx context.Context, deviceID string,
 	return nil
 }
 
-// ListNATSMirrorDevicesNeedingUpdate lists devices with mirror deployed but stale or missing fingerprint.
+// ClearNATSMirrorApplied resets mirror state so the next ensure queues deploy instead of edit.
+func (s *DeviceStore) ClearNATSMirrorApplied(ctx context.Context, deviceID string) error {
+	if deviceID == "" {
+		return ErrInvalidInput
+	}
+	query := `UPDATE devices SET nats_mirror_deployed_at = NULL, nats_mirror_config_fingerprint = NULL WHERE id = $1`
+	args := []interface{}{deviceID}
+	if tenantID := middleware.GetTenantID(ctx); tenantID != "" {
+		query = `UPDATE devices SET nats_mirror_deployed_at = NULL, nats_mirror_config_fingerprint = NULL WHERE id = $1 AND tenant_id = $2`
+		args = append(args, tenantID)
+	}
+	result, err := s.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("clear nats mirror applied: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("clear nats mirror applied rows: %w", err)
+	}
+	if rows == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ListNATSMirrorDevicesNeedingUpdate lists devices that need deploy (never applied) or edit (stale fingerprint).
 func (s *DeviceStore) ListNATSMirrorDevicesNeedingUpdate(ctx context.Context, currentFingerprint string) ([]storage.NATSMirrorDeviceRef, error) {
 	if currentFingerprint == "" {
 		return nil, ErrInvalidInput
 	}
 	rows, err := s.db.QueryContext(ctx, `
 SELECT id, tenant_id FROM devices
-WHERE nats_mirror_deployed_at IS NOT NULL
-  AND (nats_mirror_config_fingerprint IS NULL OR nats_mirror_config_fingerprint <> $1)
+WHERE nats_mirror_deployed_at IS NULL
+   OR nats_mirror_config_fingerprint IS NULL
+   OR nats_mirror_config_fingerprint <> $1
 ORDER BY tenant_id, id`, currentFingerprint)
 	if err != nil {
 		return nil, fmt.Errorf("list nats mirror devices needing update: %w", err)


### PR DESCRIPTION
## What this changes

The feature in Device Management (DM) can automatically deploy and maintain a single **data flow component** on each edge DCD (umh-core instance) that mirrors **all** Unified Namespace (UNS) traffic to a platform NATS cluster. The mirror is **not** configured per tag or bridge: one `UNS-to-NATS-mirror` component subscribes to every UNS topic and publishes to NATS with a tenant- and device-scoped subject layout.

## Why

DCD UNS data needs to be sent to upstream NATS and this configuration should be automated for each registered device for all UNS topics. 

## How to test

- Make sure the db is having the schema updated related to NATS output
- Set TAKSA_DM_NATS_MIRROR_URLS variable in .env
- Run device-management and register a device
- Run the registered device
- `UNS-to-NATS-mirror` should automatically get added to device's config.yaml after the device logs in.
